### PR TITLE
fix build failure: com.vesoft:client:3.0-SNAPSHOT does not exist in m…

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>nebula-flink-connector</artifactId>
 
     <properties>
-        <nebula.version>3.0-SNAPSHOT</nebula.version>
+        <nebula.version>3.0.0</nebula.version>
         <flink.version>1.11.3</flink.version>
         <scala.binary.version>2.11</scala.binary.version>
         <compiler.source.version>1.8</compiler.source.version>


### PR DESCRIPTION
fix build failure: com.vesoft:client:3.0-SNAPSHOT does not exist in maven centre repository

![image](https://user-images.githubusercontent.com/9884987/168726098-648df770-9bd5-4541-b596-9a5bb45b9402.png)
