### PR TITLE
fix list table names

### DIFF
--- a/connector/src/main/java/org.apache.flink/connector/nebula/catalog/NebulaCatalog.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/catalog/NebulaCatalog.java
@@ -133,10 +133,10 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
         List<String> tables = new ArrayList<>();
         try {
             for (TagItem tag : metaClient.getTags(graphSpace)) {
-                tables.add("VERTEX" + NebulaConstant.POINT + tag.tag_name);
+                tables.add("VERTEX" + NebulaConstant.POINT + new String(tag.tag_name));
             }
             for (EdgeItem edge : metaClient.getEdges(graphSpace)) {
-                tables.add("EDGE" + NebulaConstant.POINT + edge.edge_name);
+                tables.add("EDGE" + NebulaConstant.POINT + new String(edge.edge_name));
             }
         } catch (TException | ExecuteFailedException e) {
             LOG.error("get tags or edges error,", e);


### PR DESCRIPTION
close #68 

before:
```
[VERTEX.[B@3b0143d3, EDGE.[B@7b49cea0]
```

after:
```
[VERTEX.person, EDGE.friend]
```
