### PR TITLE
Reduce code duplication in integration tests

### DIFF
--- a/connector/src/test/java/org/apache/flink/connector/nebula/MockData.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/MockData.java
@@ -5,82 +5,46 @@
 
 package org.apache.flink.connector.nebula;
 
-import com.vesoft.nebula.client.graph.NebulaPoolConfig;
-import com.vesoft.nebula.client.graph.data.HostAddress;
-import com.vesoft.nebula.client.graph.data.ResultSet;
-import com.vesoft.nebula.client.graph.exception.AuthFailedException;
-import com.vesoft.nebula.client.graph.exception.ClientServerIncompatibleException;
-import com.vesoft.nebula.client.graph.exception.IOErrorException;
-import com.vesoft.nebula.client.graph.exception.NotValidConnectionException;
-import com.vesoft.nebula.client.graph.net.NebulaPool;
-import com.vesoft.nebula.client.graph.net.Session;
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class MockData {
-    private static final Logger LOGGER =
-            LoggerFactory.getLogger(MockData.class);
 
-    public static void mockSchema() {
-        NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();
-        List<HostAddress> addresses = Arrays.asList(new HostAddress("127.0.0.1", 9669));
-        NebulaPool pool = new NebulaPool();
-        Session session = null;
-        try {
-            pool.init(addresses, nebulaPoolConfig);
-            session = pool.getSession("root", "nebula", true);
-
-            ResultSet respStringSpace = session.execute(createStringSpace());
-            ResultSet respIntSpace = session.execute(createIntSpace());
-
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-
-
-            if (!respStringSpace.isSucceeded()) {
-                LOGGER.error("create string vid type space failed, {}",
-                        respStringSpace.getErrorMessage());
-                assert (false);
-            }
-            if (!respIntSpace.isSucceeded()) {
-                LOGGER.error("create int vid type space failed, {}",
-                        respIntSpace.getErrorMessage());
-                assert (false);
-            }
-        } catch (UnknownHostException | NotValidConnectionException
-                | IOErrorException | AuthFailedException | ClientServerIncompatibleException e) {
-            LOGGER.error("create space error, ", e);
-            assert (false);
-        } finally {
-            pool.close();
-        }
-    }
-
-
-    private static String createStringSpace() {
-        String exec = "CREATE SPACE IF NOT EXISTS test_string(partition_num=10,"
+    public static String createStringSpace() {
+        return "CREATE SPACE IF NOT EXISTS test_string(partition_num=10,"
                 + "vid_type=fixed_string(8));"
                 + "USE test_string;"
                 + "CREATE TAG IF NOT EXISTS person(col1 fixed_string(8), col2 string, col3 int32,"
                 + " col4 double, col5 date, col6 datetime, col7 time, col8 timestamp);"
                 + "CREATE EDGE IF NOT EXISTS friend(col1 fixed_string(8), col2 string, col3 "
                 + "int32, col4 double, col5 date, col6 datetime, col7 time, col8 timestamp);";
-        return exec;
     }
 
-    private static String createIntSpace() {
-        String exec = "CREATE SPACE IF NOT EXISTS test_int(partition_num=10,vid_type=int64);"
+    public static String createIntSpace() {
+        return "CREATE SPACE IF NOT EXISTS test_int(partition_num=10,vid_type=int64);"
                 + "USE test_int;"
                 + "CREATE TAG IF NOT EXISTS person(col1 fixed_string(8), col2 string, col3 int32,"
                 + " col4 double, col5 date, col6 datetime, col7 time, col8 timestamp);"
                 + "CREATE EDGE IF NOT EXISTS friend(col1 fixed_string(8), col2 string, col3 "
                 + "int32, col4 double, col5 date, col6 datetime, col7 time, col8 timestamp);";
-        return exec;
+    }
+
+    public static String createFlinkSinkSpace() {
+        return "CREATE SPACE IF NOT EXISTS flink_sink(partition_num=10,"
+                + "vid_type=fixed_string(8));"
+                + "USE flink_sink;"
+                + "CREATE TAG IF NOT EXISTS player(name string, age int);";
+    }
+
+    public static String createFlinkTestSpace() {
+        return "CLEAR SPACE IF EXISTS `flink_test`;"
+                + " CREATE SPACE IF NOT EXISTS `flink_test` (partition_num = 100,"
+                + " charset = utf8, replica_factor = 3, collate = utf8_bin, vid_type = INT64);"
+                + " USE `flink_test`;"
+                + " CREATE TAG IF NOT EXISTS person (col1 string, col2 fixed_string(8),"
+                + " col3 int8, col4 int16, col5 int32, col6 int64,"
+                + " col7 date, col8 datetime, col9 timestamp, col10 bool,"
+                + " col11 double, col12 float, col13 time, col14 geography);"
+                + " CREATE EDGE IF NOT EXISTS friend (col1 string, col2 fixed_string(8),"
+                + " col3 int8, col4 int16, col5 int32, col6 int64,"
+                + " col7 date, col8 datetime, col9 timestamp, col10 bool,"
+                + " col11 double, col12 float, col13 time, col14 geography);";
     }
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/NebulaITTestBase.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/NebulaITTestBase.java
@@ -58,15 +58,13 @@ public class NebulaITTestBase {
         }
     }
 
-    protected static void initializeNebulaSchema(String... statements) {
-        for (String stmt : statements) {
-            executeNGql(stmt);
-            // wait for at least two heartbeat cycles
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+    protected static void initializeNebulaSchema(String statement) {
+        executeNGql(statement);
+        // wait for at least two heartbeat cycles
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/connector/src/test/java/org/apache/flink/connector/nebula/NebulaITTestBase.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/NebulaITTestBase.java
@@ -22,49 +22,18 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import org.apache.flink.connector.nebula.utils.NebulaConstant;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.TableEnvironment;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 
 public class NebulaITTestBase {
 
     protected static final String META_ADDRESS = "127.0.0.1:9559";
     protected static final String GRAPH_ADDRESS = "127.0.0.1:9669";
-    protected static final String USER_NAME = "root";
+    protected static final String USERNAME = "root";
     protected static final String PASSWORD = "nebula";
 
-    private static final String[] NEBULA_SCHEMA_STATEMENTS = new String[]{
-        "CLEAR SPACE IF EXISTS `flink_test`;"
-                + " CREATE SPACE IF NOT EXISTS `flink_test` (partition_num = 100,"
-                + " charset = utf8, replica_factor = 3, collate = utf8_bin, vid_type = INT64);"
-                + " USE `flink_test`;",
-        "CREATE TAG IF NOT EXISTS person (col1 string, col2 fixed_string(8),"
-                + " col3 int8, col4 int16, col5 int32, col6 int64,"
-                + " col7 date, col8 datetime, col9 timestamp, col10 bool,"
-                + " col11 double, col12 float, col13 time, col14 geography);"
-                + " CREATE EDGE IF NOT EXISTS friend (col1 string, col2 fixed_string(8),"
-                + " col3 int8, col4 int16, col5 int32, col6 int64,"
-                + " col7 date, col8 datetime, col9 timestamp, col10 bool,"
-                + " col11 double, col12 float, col13 time, col14 geography);"
-    };
     protected static Session session;
     protected static NebulaPool pool;
-    protected static TableEnvironment tableEnvironment;
 
-    @BeforeClass
-    public static void beforeAll() throws IOErrorException {
-        initializeNebulaSession();
-        initializeNebulaSchema();
-    }
-
-    @AfterClass
-    public static void afterAll() {
-        closeNebulaSession();
-    }
-
-    private static void initializeNebulaSession() throws IOErrorException {
+    protected static void initializeNebulaSession() {
         NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();
         String[] addressAndPort = GRAPH_ADDRESS.split(NebulaConstant.COLON);
         List<HostAddress> addresses = Collections.singletonList(
@@ -77,19 +46,20 @@ public class NebulaITTestBase {
                 throw new RuntimeException("failed to initialize connection pool");
             }
         } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("init nebula pool error", e);
         }
         try {
-            session = pool.getSession(USER_NAME, PASSWORD, true);
+            session = pool.getSession(USERNAME, PASSWORD, true);
         } catch (NotValidConnectionException
                  | AuthFailedException
+                 | IOErrorException
                  | ClientServerIncompatibleException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("init nebula session error", e);
         }
     }
 
-    private static void initializeNebulaSchema() throws IOErrorException {
-        for (String stmt : NEBULA_SCHEMA_STATEMENTS) {
+    protected static void initializeNebulaSchema(String... statements) {
+        for (String stmt : statements) {
             executeNGql(stmt);
             // wait for at least two heartbeat cycles
             try {
@@ -100,7 +70,7 @@ public class NebulaITTestBase {
         }
     }
 
-    private static void closeNebulaSession() {
+    protected static void closeNebulaSession() {
         if (session != null) {
             session.release();
         }
@@ -109,13 +79,13 @@ public class NebulaITTestBase {
         }
     }
 
-    @Before
-    public void before() {
-        tableEnvironment = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
-    }
-
-    protected static ResultSet executeNGql(String stmt) throws IOErrorException {
-        ResultSet response = session.execute(stmt);
+    protected static ResultSet executeNGql(String stmt) {
+        ResultSet response;
+        try {
+            response = session.execute(stmt);
+        } catch (IOErrorException e) {
+            throw new RuntimeException(String.format("failed to execute statement %s", stmt), e);
+        }
         if (!response.isSucceeded()) {
             throw new RuntimeException(String.format(
                     "failed to execute statement %s with error: %s",
@@ -125,12 +95,7 @@ public class NebulaITTestBase {
     }
 
     protected static void check(List<Row> expected, String stmt) {
-        ResultSet response;
-        try {
-            response = executeNGql(stmt);
-        } catch (IOErrorException e) {
-            throw new RuntimeException(String.format("failed to check result of %s", stmt), e);
-        }
+        ResultSet response = executeNGql(stmt);
         if (expected == null || expected.isEmpty()) {
             assertTrue(response.isEmpty());
         } else {

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
@@ -12,17 +12,24 @@ import static org.apache.flink.connector.nebula.NebulaValueUtils.rowOf;
 import static org.apache.flink.connector.nebula.NebulaValueUtils.timeOf;
 import static org.apache.flink.connector.nebula.NebulaValueUtils.valueOf;
 
+import com.vesoft.nebula.client.graph.exception.IOErrorException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +38,24 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(AbstractNebulaOutputFormatITTest.class);
+
+    private static TableEnvironment tableEnvironment;
+
+    @BeforeClass
+    public static void beforeAll() {
+        initializeNebulaSession();
+        initializeNebulaSchema(MockData.createFlinkTestSpace());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        closeNebulaSession();
+    }
+
+    @Before
+    public void before() {
+        tableEnvironment = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+    }
 
     /**
      * sink Nebula Graph Vertex Data with default INSERT mode
@@ -67,7 +92,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + GRAPH_ADDRESS
                         + "',"
                         + "'username'='"
-                        + USER_NAME
+                        + USERNAME
                         + "',"
                         + "'password'='"
                         + PASSWORD
@@ -206,7 +231,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + GRAPH_ADDRESS
                         + "',"
                         + "'username'='"
-                        + USER_NAME
+                        + USERNAME
                         + "',"
                         + "'password'='"
                         + PASSWORD
@@ -268,7 +293,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + GRAPH_ADDRESS
                         + "',"
                         + "'username'='"
-                        + USER_NAME
+                        + USERNAME
                         + "',"
                         + "'password'='"
                         + PASSWORD
@@ -347,7 +372,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + GRAPH_ADDRESS
                         + "',"
                         + "'username'='"
-                        + USER_NAME
+                        + USERNAME
                         + "',"
                         + "'password'='"
                         + PASSWORD
@@ -462,7 +487,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + GRAPH_ADDRESS
                         + "',"
                         + "'username'='"
-                        + USER_NAME
+                        + USERNAME
                         + "',"
                         + "'password'='"
                         + PASSWORD

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatTest.java
@@ -5,34 +5,43 @@
 
 package org.apache.flink.connector.nebula.sink;
 
-import com.vesoft.nebula.client.graph.NebulaPoolConfig;
-import com.vesoft.nebula.client.graph.data.HostAddress;
-import com.vesoft.nebula.client.graph.data.ResultSet;
-import com.vesoft.nebula.client.graph.net.NebulaPool;
-import com.vesoft.nebula.client.graph.net.Session;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.flink.connector.nebula.MockData;
+import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.connection.NebulaClientOptions;
 import org.apache.flink.connector.nebula.connection.NebulaGraphConnectionProvider;
 import org.apache.flink.connector.nebula.connection.NebulaMetaConnectionProvider;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
 import org.apache.flink.types.Row;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AbstractNebulaOutputFormatTest {
+public class AbstractNebulaOutputFormatTest extends NebulaITTestBase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(AbstractNebulaOutputFormatTest.class);
 
+    @BeforeClass
+    public static void beforeAll() {
+        initializeNebulaSession();
+        initializeNebulaSchema(MockData.createFlinkSinkSpace());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        closeNebulaSession();
+    }
+
     @Test
     public void testWrite() throws IOException {
-        mockNebulaData();
         List<String> cols = Arrays.asList("name", "age");
         VertexExecutionOptions executionOptions =
                 new VertexExecutionOptions.ExecutionOptionBuilder()
-                        .setGraphSpace("flinkSink")
+                        .setGraphSpace("flink_sink")
                         .setTag("player")
                         .setFields(cols)
                         .setPositions(Arrays.asList(1, 2))
@@ -42,8 +51,8 @@ public class AbstractNebulaOutputFormatTest {
 
         NebulaClientOptions clientOptions = new NebulaClientOptions
                 .NebulaClientOptionsBuilder()
-                .setMetaAddress("127.0.0.1:9559")
-                .setGraphAddress("127.0.0.1:9669")
+                .setMetaAddress(META_ADDRESS)
+                .setGraphAddress(GRAPH_ADDRESS)
                 .build();
         NebulaGraphConnectionProvider graphProvider =
                 new NebulaGraphConnectionProvider(clientOptions);
@@ -58,37 +67,5 @@ public class AbstractNebulaOutputFormatTest {
 
         outputFormat.open(1, 2);
         outputFormat.writeRecord(row);
-    }
-
-    private void mockNebulaData() {
-        NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();
-        nebulaPoolConfig.setMaxConnSize(100);
-        List<HostAddress> addresses = Arrays.asList(new HostAddress("127.0.0.1", 9669));
-        NebulaPool pool = new NebulaPool();
-        Session session = null;
-        try {
-            pool.init(addresses, nebulaPoolConfig);
-            session = pool.getSession("root", "nebula", true);
-
-            String createSpace = "CREATE SPACE IF NOT EXISTS flinkSink(partition_num=10,"
-                    + "vid_type=fixed_string(8));"
-                    + "USE flinkSink;"
-                    + "CREATE TAG IF NOT EXISTS player(name string, age int);";
-            ResultSet resp = session.execute(createSpace);
-
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            if (!resp.isSucceeded()) {
-                LOGGER.error("create flinkSink space failed, " + resp.getErrorMessage());
-                assert (false);
-            }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
     }
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
@@ -35,7 +35,8 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
     @BeforeClass
     public static void beforeAll() {
         initializeNebulaSession();
-        initializeNebulaSchema(MockData.createIntSpace(), MockData.createStringSpace());
+        initializeNebulaSchema(MockData.createIntSpace());
+        initializeNebulaSchema(MockData.createStringSpace());
     }
 
     @AfterClass

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
@@ -6,42 +6,45 @@
 package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.PropertyType;
-import com.vesoft.nebula.client.graph.NebulaPoolConfig;
-import com.vesoft.nebula.client.graph.data.HostAddress;
-import com.vesoft.nebula.client.graph.data.ResultSet;
-import com.vesoft.nebula.client.graph.exception.IOErrorException;
-import com.vesoft.nebula.client.graph.net.NebulaPool;
-import com.vesoft.nebula.client.graph.net.Session;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
+import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
-import org.apache.flink.connector.nebula.statement.ExecutionOptions;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NebulaEdgeBatchExecutorTest {
+public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(NebulaEdgeBatchExecutorTest.class);
 
-    String ip = "127.0.0.1";
     EdgeExecutionOptions.ExecutionOptionBuilder builder = null;
     Map<String, Integer> schema = new HashMap<>();
     Row row1 = new Row(10);
     Row row2 = new Row(10);
 
-    Session session = null;
+    @BeforeClass
+    public static void beforeAll() {
+        initializeNebulaSession();
+        initializeNebulaSchema(MockData.createIntSpace(), MockData.createStringSpace());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        closeNebulaSession();
+    }
 
     @Before
     public void before() {
-        MockData.mockSchema();
         builder = new EdgeExecutionOptions.ExecutionOptionBuilder()
                 .setEdge("friend")
                 .setSrcIndex(0)
@@ -80,18 +83,6 @@ public class NebulaEdgeBatchExecutorTest {
         row2.setField(7, "2021-02-01T12:00:00");
         row2.setField(8, "15:00:00");
         row2.setField(9, 392435234);
-
-        // get Session
-        NebulaPoolConfig poolConfig = new NebulaPoolConfig();
-        NebulaPool pool = new NebulaPool();
-
-        try {
-            pool.init(Arrays.asList(new HostAddress(ip, 9669)), poolConfig);
-            session = pool.getSession("root", "nebula", true);
-        } catch (Exception e) {
-            LOGGER.error("init nebula pool error, ", e);
-            assert (false);
-        }
     }
 
     /**
@@ -196,17 +187,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -228,17 +209,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -258,17 +229,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -288,17 +249,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -319,17 +270,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -349,17 +290,7 @@ public class NebulaEdgeBatchExecutorTest {
         edgeBatchExecutor.addToBatch(row1);
         edgeBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = edgeBatchExecutor.executeBatch(session);
         assert (statement == null);

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
@@ -6,41 +6,45 @@
 package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.PropertyType;
-import com.vesoft.nebula.client.graph.NebulaPoolConfig;
-import com.vesoft.nebula.client.graph.data.HostAddress;
-import com.vesoft.nebula.client.graph.data.ResultSet;
-import com.vesoft.nebula.client.graph.exception.IOErrorException;
-import com.vesoft.nebula.client.graph.net.NebulaPool;
-import com.vesoft.nebula.client.graph.net.Session;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
-import org.apache.flink.connector.nebula.statement.ExecutionOptions;
+import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NebulaVertexBatchExecutorTest {
+public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
+
     private static final Logger LOGGER =
             LoggerFactory.getLogger(NebulaVertexBatchExecutorTest.class);
 
-    String ip = "127.0.0.1";
     VertexExecutionOptions.ExecutionOptionBuilder builder = null;
     Map<String, Integer> schema = new HashMap<>();
     Row row1 = new Row(9);
     Row row2 = new Row(9);
 
-    Session session = null;
+    @BeforeClass
+    public static void beforeAll() {
+        initializeNebulaSession();
+        initializeNebulaSchema(MockData.createIntSpace(), MockData.createStringSpace());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        closeNebulaSession();
+    }
 
     @Before
     public void before() {
-        MockData.mockSchema();
         builder = new VertexExecutionOptions.ExecutionOptionBuilder()
                 .setTag("person")
                 .setIdIndex(0)
@@ -76,18 +80,6 @@ public class NebulaVertexBatchExecutorTest {
         row2.setField(6, "2021-02-01T12:00:00");
         row2.setField(7, "15:00:00");
         row2.setField(8, 392435234);
-
-        // get Session
-        NebulaPoolConfig poolConfig = new NebulaPoolConfig();
-        NebulaPool pool = new NebulaPool();
-
-        try {
-            pool.init(Arrays.asList(new HostAddress(ip, 9669)), poolConfig);
-            session = pool.getSession("root", "nebula", true);
-        } catch (Exception e) {
-            LOGGER.error("init nebula pool error, ", e);
-            assert (false);
-        }
     }
 
     /**
@@ -192,17 +184,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -224,17 +206,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -254,17 +226,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_int");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_int");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -284,17 +246,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -315,17 +267,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);
@@ -345,17 +287,7 @@ public class NebulaVertexBatchExecutorTest {
         vertexBatchExecutor.addToBatch(row1);
         vertexBatchExecutor.addToBatch(row2);
 
-        ResultSet resultSet = null;
-        try {
-            resultSet = session.execute("USE test_string");
-        } catch (IOErrorException e) {
-            LOGGER.error("switch space error,", e);
-            assert (false);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOGGER.error("switch space failed,{}", resultSet.getErrorMessage());
-            assert (false);
-        }
+        executeNGql("USE test_string");
 
         String statement = vertexBatchExecutor.executeBatch(session);
         assert (statement == null);

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
@@ -35,7 +35,8 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
     @BeforeClass
     public static void beforeAll() {
         initializeNebulaSession();
-        initializeNebulaSchema(MockData.createIntSpace(), MockData.createStringSpace());
+        initializeNebulaSchema(MockData.createIntSpace());
+        initializeNebulaSchema(MockData.createStringSpace());
     }
 
     @AfterClass

--- a/connector/src/test/java/org/apache/flink/connector/nebula/source/AbstractNebulaInputFormatITTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/source/AbstractNebulaInputFormatITTest.java
@@ -10,13 +10,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.utils.NebulaEdge;
 import org.apache.flink.connector.nebula.utils.NebulaEdges;
 import org.apache.flink.connector.nebula.utils.NebulaVertex;
 import org.apache.flink.connector.nebula.utils.NebulaVertices;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +32,25 @@ public class AbstractNebulaInputFormatITTest extends NebulaITTestBase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(AbstractNebulaInputFormatITTest.class);
 
+    private static TableEnvironment tableEnvironment;
     private final String[] colNames = {"col1", "col2", "col3", "col4", "col5", "col6", "col7",
                                        "col8", "col9", "col10", "col11", "col12", "col13", "col14"};
+
+    @BeforeClass
+    public static void beforeAll() {
+        initializeNebulaSession();
+        initializeNebulaSchema(MockData.createFlinkTestSpace());
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        closeNebulaSession();
+    }
+
+    @Before
+    public void before() {
+        tableEnvironment = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+    }
 
     /**
      * construct flink vertex data


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement (small refactoring)

## What problem(s) does this PR solve?

#### Issue(s) number: N/A

#### Description:

The integration tests contain duplicated code for initializing session, defining schema, and executing nGQL statements, etc. We can do some refactoring to extract shared logic for all tests.

## How do you solve it?

I refactored a few test classes to make them inherit from `NebulaITTestBase` which contains shared logic for test setup. There is no change to the functionality.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

N/A