### PR TITLE
Improve connector failure handling logic

### DIFF
--- a/connector/src/main/java/org.apache.flink/connector/nebula/catalog/NebulaCatalog.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/catalog/NebulaCatalog.java
@@ -98,7 +98,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
         try {
             this.metaClient = metaConnectionProvider.getMetaClient();
         } catch (UnknownHostException | ClientServerIncompatibleException e) {
-            LOG.error("nebula get meta client error, ", e);
+            LOG.error("nebula get meta client error", e);
             throw new CatalogException("nebula get meta client error.", e);
         }
 
@@ -108,8 +108,8 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
                     graphConnectionProvider.getPassword(), true);
         } catch (NotValidConnectionException | IOErrorException | AuthFailedException
                 | ClientServerIncompatibleException | UnknownHostException e) {
-            LOG.error("failed to get graph session, ", e);
-            throw new CatalogException("get graph session error, ", e);
+            LOG.error("failed to get graph session", e);
+            throw new CatalogException("get graph session error.", e);
         }
     }
 
@@ -137,7 +137,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
                 spaceNames.add(new String(space.getName()));
             }
         } catch (TException | ExecuteFailedException | ClientServerIncompatibleException e) {
-            LOG.error("failed to connect meta service vis {} ", address, e);
+            LOG.error("failed to connect meta service via " + address, e);
             throw new CatalogException("nebula meta service connect failed.", e);
         }
         return spaceNames;
@@ -152,7 +152,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
                 props.put("spaceId",
                         String.valueOf(metaClient.getSpace(databaseName).getSpace_id()));
             } catch (TException | ExecuteFailedException e) {
-                LOG.error("get spaceId error, ", e);
+                LOG.error("get spaceId error", e);
             }
             return new CatalogDatabaseImpl(props, databaseName);
         } else {
@@ -186,13 +186,13 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
             )
         );
         if (!newProperties.containsKey(NebulaConstant.CREATE_VID_TYPE)) {
-            LOG.error("failed to create graph space {}, missing VID type param", properties);
+            LOG.error("failed to create graph space {}, missing VID type", properties);
             throw new CatalogException("nebula create graph space failed, missing VID type.");
         }
         String vidType = newProperties.get(NebulaConstant.CREATE_VID_TYPE);
         if (!NebulaUtils.checkValidVidType(vidType)) {
-            LOG.error("VID type not satisfy {}", vidType);
-            throw new CatalogException("nebula graph dont support VID type.");
+            LOG.error("invalid VID type: {}", vidType);
+            throw new CatalogException("nebula does not support the specified VID type.");
         }
         NebulaSpace space = new NebulaSpace(
                 dataBaseName,catalogDatabase.getComment(), newProperties);
@@ -210,7 +210,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
             LOG.debug("create space success.");
         } else {
             LOG.error("create space failed: {}", execResult.getErrorMessage());
-            throw new CatalogException("create space failed, " + execResult.getErrorMessage());
+            throw new CatalogException("create space failed: " + execResult.getErrorMessage());
         }
     }
 
@@ -227,7 +227,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
         try {
             return (listTables(graphSpace).contains(table));
         } catch (DatabaseNotExistException e) {
-            throw new CatalogException("failed to call tableExists function, ", e);
+            throw new CatalogException("failed to call tableExists function.", e);
         }
     }
 
@@ -248,7 +248,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
         try {
             metaClient.connect();
         } catch (TException | ClientServerIncompatibleException e) {
-            LOG.error("failed to connect meta service vis {} ", address, e);
+            LOG.error("failed to connect meta service via " + address, e);
             throw new CatalogException("nebula meta service connect failed.", e);
         }
         List<String> tables = new ArrayList<>();
@@ -260,7 +260,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
                 tables.add("EDGE" + NebulaConstant.POINT + new String(edge.edge_name));
             }
         } catch (TException | ExecuteFailedException e) {
-            LOG.error("get tags or edges error,", e);
+            LOG.error("get tags or edges error", e);
         }
         return tables;
     }
@@ -284,7 +284,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
         try {
             metaClient.connect();
         } catch (TException | ClientServerIncompatibleException e) {
-            LOG.error("failed to connect meta service vis {} ", address, e);
+            LOG.error("failed to connect meta service via " + address, e);
             throw new CatalogException("nebula meta service connect failed.", e);
         }
 
@@ -296,7 +296,7 @@ public class NebulaCatalog extends AbstractNebulaCatalog {
                 schema = metaClient.getEdge(graphSpace, label);
             }
         } catch (TException | ExecuteFailedException e) {
-            LOG.error("get tag or edge schema error, ", e);
+            LOG.error("get tag or edge schema error", e);
             return null;
         }
 

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
@@ -30,8 +30,8 @@ public abstract class NebulaBatchExecutor<T> {
      */
     public abstract void executeBatch(Session session);
 
-    protected static void executeStatement(Session session, String statement, int maxRetries)
-            throws IOException {
+    protected static void executeStatement(Session session, String statement,
+                                           int maxRetries, int retryDelayMs) throws IOException {
         if (maxRetries < 0) {
             throw new IllegalArgumentException(
                     String.format("invalid max retries: %s", maxRetries));
@@ -56,8 +56,7 @@ public abstract class NebulaBatchExecutor<T> {
                     throw new IOException(e);
                 } else if (i + 1 <= maxRetries) {
                     try {
-                        int wait = NebulaConstant.EXECUTION_RETRY_WAIT_INCREMENT_MS * (i + 1);
-                        Thread.sleep(wait);
+                        Thread.sleep(retryDelayMs);
                     } catch (InterruptedException ex) {
                         Thread.currentThread().interrupt();
                         throw new IOException("interrupted", ex);

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
@@ -21,5 +21,5 @@ public interface NebulaBatchExecutor<T> {
      *
      * @param session graph session
      */
-    String executeBatch(Session session);
+    void executeBatch(Session session);
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
@@ -5,6 +5,7 @@
 
 package org.apache.flink.connector.nebula.sink;
 
+import com.vesoft.nebula.ErrorCode;
 import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.exception.IOErrorException;
 import com.vesoft.nebula.client.graph.net.Session;
@@ -13,6 +14,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class NebulaBatchExecutor<T> {
+
+    public static class ExecutionException extends IOException {
+        private final String statement;
+        private final String errorMessage;
+        private final int errorCode;
+
+        public ExecutionException(String statement, String errorMessage, int errorCode) {
+            this.statement = statement;
+            this.errorMessage = errorMessage;
+            this.errorCode = errorCode;
+        }
+
+        @Override
+        public String getMessage() {
+            return String.format("failed to execute statement %s: %s [%s]",
+                    statement, errorMessage, errorCode);
+        }
+
+        public boolean isNonRecoverableError() {
+            return this.errorCode == ErrorCode.E_SEMANTIC_ERROR.getValue()
+                    || this.errorCode == ErrorCode.E_SYNTAX_ERROR.getValue();
+        }
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(NebulaBatchExecutor.class);
 
@@ -45,9 +69,8 @@ public abstract class NebulaBatchExecutor<T> {
         if (execResult.isSucceeded()) {
             LOG.debug("write success");
         } else {
-            throw new IOException(String.format(
-                    "write data failed for statement %s: %s [%s]",
-                    statement, execResult.getErrorMessage(), execResult.getErrorCode()));
+            throw new ExecutionException(
+                    statement, execResult.getErrorMessage(), execResult.getErrorCode());
         }
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchExecutor.java
@@ -5,21 +5,65 @@
 
 package org.apache.flink.connector.nebula.sink;
 
+import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.net.Session;
+import java.io.IOException;
+import org.apache.flink.connector.nebula.utils.NebulaConstant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public interface NebulaBatchExecutor<T> {
+public abstract class NebulaBatchExecutor<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NebulaBatchExecutor.class);
 
     /**
      * put record into buffer
      *
      * @param record represent vertex or edge
      */
-    void addToBatch(T record);
+    public abstract void addToBatch(T record);
 
     /**
      * execute the statement
      *
      * @param session graph session
      */
-    void executeBatch(Session session);
+    public abstract void executeBatch(Session session);
+
+    protected static void executeStatement(Session session, String statement, int maxRetries)
+            throws IOException {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException(
+                    String.format("invalid max retries: %s", maxRetries));
+        }
+
+        // The statement will be executed at most `maxRetries + 1` times.
+        for (int i = 0; i <= maxRetries; i++) {
+            ResultSet execResult;
+            try {
+                execResult = session.execute(statement);
+                if (execResult.isSucceeded()) {
+                    LOG.debug("write success");
+                    break;
+                } else {
+                    throw new IOException(String.format(
+                            "write data failed for statement %s: %s [%s]",
+                            statement, execResult.getErrorMessage(), execResult.getErrorCode()));
+                }
+            } catch (Exception e) {
+                LOG.error(String.format("write data error (attempt %s)", i), e);
+                if (i >= maxRetries) {
+                    throw new IOException(e);
+                } else if (i + 1 <= maxRetries) {
+                    try {
+                        int wait = NebulaConstant.EXECUTION_RETRY_WAIT_INCREMENT_MS * (i + 1);
+                        Thread.sleep(wait);
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("interrupted", ex);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchOutputFormat.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaBatchOutputFormat.java
@@ -17,8 +17,6 @@ import com.vesoft.nebula.client.meta.MetaClient;
 import java.io.Flushable;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.nebula.connection.NebulaGraphConnectionProvider;
 import org.apache.flink.connector.nebula.connection.NebulaMetaConnectionProvider;
 import org.apache.flink.connector.nebula.statement.ExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,13 +41,14 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
     protected final NebulaGraphConnectionProvider graphProvider;
     protected final OptionsT executionOptions;
     protected NebulaBatchExecutor<T> nebulaBatchExecutor;
-    private volatile AtomicLong numPendingRow;
+    private transient long numPendingRow;
     private NebulaPool nebulaPool;
     private Session session;
 
     private transient ScheduledExecutorService scheduler;
     private transient ScheduledFuture<?> scheduledFuture;
     private transient volatile boolean closed = false;
+    private transient volatile Exception commitException;
 
     public NebulaBatchOutputFormat(
             NebulaGraphConnectionProvider graphProvider,
@@ -70,33 +70,20 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
     public void open(int i, int i1) throws IOException {
         try {
             nebulaPool = graphProvider.getNebulaPool();
-            session = nebulaPool.getSession(graphProvider.getUserName(),
-                    graphProvider.getPassword(), true);
-        } catch (UnknownHostException | NotValidConnectionException | AuthFailedException
-                | ClientServerIncompatibleException | IOErrorException e) {
-            LOG.error("failed to get graph session, ", e);
-            throw new IOException("get graph session error, ", e);
+        } catch (UnknownHostException e) {
+            LOG.error("failed to create connection pool", e);
+            throw new IOException("connection pool creation error", e);
         }
-        ResultSet resultSet;
-        try {
-            resultSet = session.execute("USE " + executionOptions.getGraphSpace());
-        } catch (IOErrorException e) {
-            LOG.error("switch space error, ", e);
-            throw new IOException("switch space error,", e);
-        }
-        if (!resultSet.isSucceeded()) {
-            LOG.error("switch space failed, {}", resultSet.getErrorMessage());
-            throw new RuntimeException("switch space failed, " + resultSet.getErrorMessage());
-        }
+        renewSession();
 
         try {
             metaClient = metaProvider.getMetaClient();
         } catch (TException | ClientServerIncompatibleException e) {
-            LOG.error("failed to get meta client, ", e);
-            throw new IOException("get metaClient error, ", e);
+            LOG.error("failed to get meta client", e);
+            throw new IOException("get meta client error", e);
         }
 
-        numPendingRow = new AtomicLong(0);
+        numPendingRow = 0;
         nebulaBatchExecutor = createNebulaBatchExecutor();
         // start the schedule task: submit the buffer records every batchInterval.
         // If batchIntervalMs is 0, do not start the scheduler task.
@@ -105,13 +92,49 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
                     "nebula-write-output-format"));
             this.scheduledFuture = this.scheduler.scheduleWithFixedDelay(() -> {
                 synchronized (NebulaBatchOutputFormat.this) {
-                    if (!closed) {
-                        commit();
+                    if (!closed && commitException == null) {
+                        try {
+                            commit();
+                        } catch (Exception e) {
+                            commitException = e;
+                        }
                     }
                 } },
                     executionOptions.getBatchIntervalMs(),
                     executionOptions.getBatchIntervalMs(),
                     TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void checkCommitException() {
+        if (commitException != null) {
+            throw new RuntimeException("commit records failed", commitException);
+        }
+    }
+
+    private void renewSession() throws IOException {
+        if (session != null) {
+            session.release();
+            session = null;
+        }
+        try {
+            session = nebulaPool.getSession(graphProvider.getUserName(),
+                    graphProvider.getPassword(), true);
+        } catch (NotValidConnectionException | AuthFailedException
+                 | ClientServerIncompatibleException | IOErrorException e) {
+            LOG.error("failed to get graph session", e);
+            throw new IOException("get graph session error", e);
+        }
+        ResultSet resultSet;
+        try {
+            resultSet = session.execute("USE " + executionOptions.getGraphSpace());
+        } catch (IOErrorException e) {
+            LOG.error("switch space error", e);
+            throw new IOException("switch space error", e);
+        }
+        if (!resultSet.isSucceeded()) {
+            LOG.error("switch space failed: " + resultSet.getErrorMessage());
+            throw new IOException("switch space failed: " + resultSet.getErrorMessage());
         }
     }
 
@@ -121,10 +144,13 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
      * write one record to buffer
      */
     @Override
-    public final synchronized void writeRecord(T row) {
+    public final synchronized void writeRecord(T row) throws IOException {
+        checkCommitException();
         nebulaBatchExecutor.addToBatch(row);
+        numPendingRow++;
 
-        if (numPendingRow.incrementAndGet() >= executionOptions.getBatchSize()) {
+        if (executionOptions.getBatchSize() > 0
+                && numPendingRow >= executionOptions.getBatchSize()) {
             commit();
         }
     }
@@ -132,24 +158,53 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
     /**
      * commit batch insert statements
      */
-    private synchronized void commit() {
-        nebulaBatchExecutor.executeBatch(session);
-        long pendingRow = numPendingRow.get();
-        numPendingRow.compareAndSet(pendingRow, 0);
+    private synchronized void commit() throws IOException {
+        int maxRetries = executionOptions.getMaxRetries();
+        int retryDelayMs = executionOptions.getRetryDelayMs();
+        boolean failOnError = executionOptions.getFailureHandler().equals(FailureHandlerEnum.FAIL);
+
+        // execute the batch at most `maxRetries + 1` times
+        for (int i = 0; i <= maxRetries; i++) {
+            try {
+                nebulaBatchExecutor.executeBatch(session);
+                numPendingRow = 0;
+                break;
+            } catch (Exception e) {
+                LOG.error(String.format("write data error (attempt %s)", i), e);
+                if (i >= maxRetries) {
+                    // clear the batch on failure after all retries
+                    nebulaBatchExecutor.clearBatch();
+                    numPendingRow = 0;
+                    if (failOnError) {
+                        throw e;
+                    }
+                } else if (i + 1 <= maxRetries) {
+                    try {
+                        Thread.sleep(retryDelayMs);
+                    } catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("interrupted", ex);
+                    }
+                }
+                // We do not know whether the failure was due to an expired session or
+                // an issue with the query, so we renew the session anyway to be more robust.
+                renewSession();
+            }
+        }
     }
 
     /**
      * commit the batch write operator before release connection
      */
     @Override
-    public final synchronized void close() {
+    public final synchronized void close() throws IOException {
         if (!closed) {
             closed = true;
             if (scheduledFuture != null) {
                 scheduledFuture.cancel(false);
                 scheduler.shutdown();
             }
-            if (numPendingRow != null && numPendingRow.get() > 0) {
+            if (numPendingRow > 0) {
                 commit();
             }
             if (session != null) {
@@ -169,7 +224,8 @@ public abstract class NebulaBatchOutputFormat<T, OptionsT extends ExecutionOptio
      */
     @Override
     public synchronized void flush() throws IOException {
-        while (numPendingRow.get() != 0) {
+        checkCommitException();
+        while (numPendingRow > 0) {
             commit();
         }
     }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
@@ -44,9 +44,9 @@ public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
     }
 
     @Override
-    public String executeBatch(Session session) {
+    public void executeBatch(Session session) {
         if (nebulaEdgeList.size() == 0) {
-            return null;
+            return;
         }
         NebulaEdges nebulaEdges = new NebulaEdges(executionOptions.getLabel(),
                 executionOptions.getFields(), nebulaEdgeList, executionOptions.getPolicy(),
@@ -75,7 +75,7 @@ public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
         } catch (Exception e) {
             LOG.error("write data error, ", e);
             nebulaEdgeList.clear();
-            return statement;
+            return;
         }
 
         if (execResult.isSucceeded()) {
@@ -83,9 +83,8 @@ public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
         } else {
             LOG.error("write data failed: {}", execResult.getErrorMessage());
             nebulaEdgeList.clear();
-            return statement;
+            return;
         }
         nebulaEdgeList.clear();
-        return null;
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
@@ -70,7 +70,8 @@ public class NebulaEdgeBatchExecutor extends NebulaBatchExecutor<Row> {
         LOG.debug("write statement: {}", statement);
 
         try {
-            executeStatement(session, statement, executionOptions.getMaxRetries());
+            executeStatement(session, statement,
+                    executionOptions.getMaxRetries(), executionOptions.getRetryDelayMs());
         } catch (IOException e) {
             if (executionOptions.getFailureHandler().equals(FailureHandlerEnum.FAIL)) {
                 throw new RuntimeException(e);

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
@@ -5,12 +5,13 @@
 
 package org.apache.flink.connector.nebula.sink;
 
-import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.net.Session;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.NebulaEdge;
 import org.apache.flink.connector.nebula.utils.NebulaEdges;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
@@ -18,7 +19,7 @@ import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
+public class NebulaEdgeBatchExecutor extends NebulaBatchExecutor<Row> {
     private static final Logger LOG = LoggerFactory.getLogger(NebulaEdgeBatchExecutor.class);
     private final EdgeExecutionOptions executionOptions;
     private final List<NebulaEdge> nebulaEdgeList;
@@ -66,24 +67,14 @@ public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
             default:
                 throw new IllegalArgumentException("write mode is not supported");
         }
-        LOG.debug("write statement={}", statement);
+        LOG.debug("write statement: {}", statement);
 
-        // execute ngql statement
-        ResultSet execResult = null;
         try {
-            execResult = session.execute(statement);
-        } catch (Exception e) {
-            LOG.error("write data error, ", e);
-            nebulaEdgeList.clear();
-            return;
-        }
-
-        if (execResult.isSucceeded()) {
-            LOG.debug("write success");
-        } else {
-            LOG.error("write data failed: {}", execResult.getErrorMessage());
-            nebulaEdgeList.clear();
-            return;
+            executeStatement(session, statement, executionOptions.getMaxRetries());
+        } catch (IOException e) {
+            if (executionOptions.getFailureHandler().equals(FailureHandlerEnum.FAIL)) {
+                throw new RuntimeException(e);
+            }
         }
         nebulaEdgeList.clear();
     }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaSinkFunction.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaSinkFunction.java
@@ -41,12 +41,12 @@ public class NebulaSinkFunction<T> extends RichSinkFunction<T> implements Checkp
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
         outputFormat.close();
     }
 
     @Override
-    public void invoke(T value, Context context) {
+    public void invoke(T value, Context context) throws Exception {
         checkErrorAndRethrow();
         outputFormat.writeRecord(value);
     }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaTableBufferReducedExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaTableBufferReducedExecutor.java
@@ -9,7 +9,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConve
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 
-public class NebulaTableBufferReducedExecutor implements NebulaBatchExecutor<RowData> {
+public class NebulaTableBufferReducedExecutor extends NebulaBatchExecutor<RowData> {
     private final DataStructureConverter dataStructureConverter;
     private final Function<Row, Row> keyExtractor;
     private final NebulaBatchExecutor<Row> insertExecutor;

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
@@ -5,12 +5,13 @@
 
 package org.apache.flink.connector.nebula.sink;
 
-import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.net.Session;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.NebulaVertex;
 import org.apache.flink.connector.nebula.utils.NebulaVertices;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
@@ -18,7 +19,7 @@ import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NebulaVertexBatchExecutor implements NebulaBatchExecutor<Row> {
+public class NebulaVertexBatchExecutor extends NebulaBatchExecutor<Row> {
     private static final Logger LOG = LoggerFactory.getLogger(NebulaVertexBatchExecutor.class);
     private final VertexExecutionOptions executionOptions;
     private final List<NebulaVertex> nebulaVertexList;
@@ -68,24 +69,14 @@ public class NebulaVertexBatchExecutor implements NebulaBatchExecutor<Row> {
             default:
                 throw new IllegalArgumentException("write mode is not supported");
         }
-        LOG.debug("write statement={}", statement);
+        LOG.debug("write statement: {}", statement);
 
-        // execute ngql statement
-        ResultSet execResult = null;
         try {
-            execResult = session.execute(statement);
-        } catch (Exception e) {
-            LOG.error("write data error, ", e);
-            nebulaVertexList.clear();
-            return;
-        }
-
-        if (execResult.isSucceeded()) {
-            LOG.debug("write success");
-        } else {
-            LOG.error("write data failed: {}", execResult.getErrorMessage());
-            nebulaVertexList.clear();
-            return;
+            executeStatement(session, statement, executionOptions.getMaxRetries());
+        } catch (IOException e) {
+            if (executionOptions.getFailureHandler().equals(FailureHandlerEnum.FAIL)) {
+                throw new RuntimeException(e);
+            }
         }
         nebulaVertexList.clear();
     }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
@@ -72,7 +72,8 @@ public class NebulaVertexBatchExecutor extends NebulaBatchExecutor<Row> {
         LOG.debug("write statement: {}", statement);
 
         try {
-            executeStatement(session, statement, executionOptions.getMaxRetries());
+            executeStatement(session, statement,
+                    executionOptions.getMaxRetries(), executionOptions.getRetryDelayMs());
         } catch (IOException e) {
             if (executionOptions.getFailureHandler().equals(FailureHandlerEnum.FAIL)) {
                 throw new RuntimeException(e);

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaVertexBatchExecutor.java
@@ -10,7 +10,6 @@ import com.vesoft.nebula.client.graph.net.Session;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.flink.connector.nebula.statement.ExecutionOptions;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
 import org.apache.flink.connector.nebula.utils.NebulaVertex;
 import org.apache.flink.connector.nebula.utils.NebulaVertices;
@@ -48,9 +47,9 @@ public class NebulaVertexBatchExecutor implements NebulaBatchExecutor<Row> {
     }
 
     @Override
-    public String executeBatch(Session session) {
+    public void executeBatch(Session session) {
         if (nebulaVertexList.size() == 0) {
-            return null;
+            return;
         }
         NebulaVertices nebulaVertices = new NebulaVertices(executionOptions.getLabel(),
                 executionOptions.getFields(), nebulaVertexList, executionOptions.getPolicy());
@@ -78,7 +77,7 @@ public class NebulaVertexBatchExecutor implements NebulaBatchExecutor<Row> {
         } catch (Exception e) {
             LOG.error("write data error, ", e);
             nebulaVertexList.clear();
-            return statement;
+            return;
         }
 
         if (execResult.isSucceeded()) {
@@ -86,9 +85,8 @@ public class NebulaVertexBatchExecutor implements NebulaBatchExecutor<Row> {
         } else {
             LOG.error("write data failed: {}", execResult.getErrorMessage());
             nebulaVertexList.clear();
-            return statement;
+            return;
         }
         nebulaVertexList.clear();
-        return null;
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/source/NebulaInputFormat.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/source/NebulaInputFormat.java
@@ -81,8 +81,8 @@ public abstract class NebulaInputFormat<T> extends RichInputFormat<T, InputSplit
             metaClient = metaConnectionProvider.getMetaClient();
             numPart = metaClient.getPartsAlloc(executionOptions.getGraphSpace()).size();
         } catch (Exception e) {
-            LOG.error("connect storage client error, ", e);
-            throw new IOException("connect storage client error, ", e);
+            LOG.error("connect storage client error", e);
+            throw new IOException("connect storage client error", e);
         }
         rows = new ArrayList<>();
     }
@@ -97,8 +97,8 @@ public abstract class NebulaInputFormat<T> extends RichInputFormat<T, InputSplit
                 metaClient.close();
             }
         } catch (Exception e) {
-            LOG.error("close client error,", e);
-            throw new IOException("close client error,", e);
+            LOG.error("close client error", e);
+            throw new IOException("close client error", e);
         }
     }
 
@@ -135,8 +135,8 @@ public abstract class NebulaInputFormat<T> extends RichInputFormat<T, InputSplit
             try {
                 hasNext = nebulaSource.hasNext();
             } catch (Exception e) {
-                LOG.error("scan NebulaGraph error, ", e);
-                throw new IOException("scan error, ", e);
+                LOG.error("scan NebulaGraph error", e);
+                throw new IOException("scan error", e);
             }
         }
     }
@@ -157,8 +157,8 @@ public abstract class NebulaInputFormat<T> extends RichInputFormat<T, InputSplit
         try {
             hasNext = nebulaSource.hasNext();
         } catch (Exception e) {
-            LOG.error("scan NebulaGraph error, ", e);
-            throw new IOException("scan NebulaGraph error, ", e);
+            LOG.error("scan NebulaGraph error", e);
+            throw new IOException("scan NebulaGraph error", e);
         }
         scannedRows++;
         return nebulaConverter.convert(row);

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/EdgeExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/EdgeExecutionOptions.java
@@ -7,6 +7,7 @@ package org.apache.flink.connector.nebula.statement;
 
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_BATCH_INTERVAL_MS;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_EXECUTION_RETRY;
+import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_RETRY_DELAY_MS;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_ROW_INFO_INDEX;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_SCAN_LIMIT;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_WRITE_BATCH_SIZE;
@@ -42,14 +43,28 @@ public class EdgeExecutionOptions extends ExecutionOptions {
     private int rankIndex;
 
 
-    private EdgeExecutionOptions(String graphSpace, String executeStatement, List<String> fields,
-                                 List<Integer> positions, boolean noColumn, int limit,
-                                 long startTime, long endTime, int batch, PolicyEnum policy,
-                                 WriteModeEnum mode, String edge, int srcIndex, int dstIndex,
-                                 int rankIndex, int batchIntervalMs,
-                                 FailureHandlerEnum failureHandler, int maxRetries) {
+    private EdgeExecutionOptions(String graphSpace,
+                                 String executeStatement,
+                                 List<String> fields,
+                                 List<Integer> positions,
+                                 boolean noColumn,
+                                 int limit,
+                                 long startTime,
+                                 long endTime,
+                                 int batch,
+                                 PolicyEnum policy,
+                                 WriteModeEnum mode,
+                                 String edge,
+                                 int srcIndex,
+                                 int dstIndex,
+                                 int rankIndex,
+                                 int batchIntervalMs,
+                                 FailureHandlerEnum failureHandler,
+                                 int maxRetries,
+                                 int retryDelayMs) {
         super(graphSpace, executeStatement, fields, positions, noColumn, limit, startTime,
-                endTime, batch, policy, mode, batchIntervalMs, failureHandler, maxRetries);
+                endTime, batch, policy, mode, batchIntervalMs,
+                failureHandler, maxRetries, retryDelayMs);
         this.edge = edge;
         this.srcIndex = srcIndex;
         this.dstIndex = dstIndex;
@@ -102,7 +117,8 @@ public class EdgeExecutionOptions extends ExecutionOptions {
                 .setWriteMode(this.getWriteMode())
                 .setBatchIntervalMs(this.getBatchIntervalMs())
                 .setFailureHandler(this.getFailureHandler())
-                .setMaxRetries(this.getMaxRetries());
+                .setMaxRetries(this.getMaxRetries())
+                .setRetryDelayMs(this.getRetryDelayMs());
     }
 
     public static class ExecutionOptionBuilder {
@@ -124,6 +140,7 @@ public class EdgeExecutionOptions extends ExecutionOptions {
         private int rankIndex = DEFAULT_ROW_INFO_INDEX;
         private FailureHandlerEnum failureHandler = FailureHandlerEnum.IGNORE;
         private int maxRetries = DEFAULT_EXECUTION_RETRY;
+        private int retryDelayMs = DEFAULT_RETRY_DELAY_MS;
 
         public ExecutionOptionBuilder setGraphSpace(String graphSpace) {
             this.graphSpace = graphSpace;
@@ -222,6 +239,11 @@ public class EdgeExecutionOptions extends ExecutionOptions {
             return this;
         }
 
+        public ExecutionOptionBuilder setRetryDelayMs(int retryDelayMs) {
+            this.retryDelayMs = retryDelayMs;
+            return this;
+        }
+
         @Deprecated
         public EdgeExecutionOptions builder() {
             return build();
@@ -236,7 +258,7 @@ public class EdgeExecutionOptions extends ExecutionOptions {
             }
             return new EdgeExecutionOptions(graphSpace, executeStatement, fields, positions,
                     noColumn, limit, startTime, endTime, batchSize, policy, mode, edge, srcIndex,
-                    dstIndex, rankIndex, batchIntervalMs, failureHandler, maxRetries);
+                    dstIndex, rankIndex, batchIntervalMs, failureHandler, maxRetries, retryDelayMs);
         }
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/EdgeExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/EdgeExecutionOptions.java
@@ -6,6 +6,7 @@
 package org.apache.flink.connector.nebula.statement;
 
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_BATCH_INTERVAL_MS;
+import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_EXECUTION_RETRY;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_ROW_INFO_INDEX;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_SCAN_LIMIT;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_WRITE_BATCH_SIZE;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.flink.connector.nebula.utils.DataTypeEnum;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.PolicyEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 
@@ -44,9 +46,10 @@ public class EdgeExecutionOptions extends ExecutionOptions {
                                  List<Integer> positions, boolean noColumn, int limit,
                                  long startTime, long endTime, int batch, PolicyEnum policy,
                                  WriteModeEnum mode, String edge, int srcIndex, int dstIndex,
-                                 int rankIndex, int batchIntervalMs) {
+                                 int rankIndex, int batchIntervalMs,
+                                 FailureHandlerEnum failureHandler, int maxRetries) {
         super(graphSpace, executeStatement, fields, positions, noColumn, limit, startTime,
-                endTime, batch, policy, mode, batchIntervalMs);
+                endTime, batch, policy, mode, batchIntervalMs, failureHandler, maxRetries);
         this.edge = edge;
         this.srcIndex = srcIndex;
         this.dstIndex = dstIndex;
@@ -97,7 +100,9 @@ public class EdgeExecutionOptions extends ExecutionOptions {
                 .setDstIndex(this.getDstIndex())
                 .setRankIndex(this.getRankIndex())
                 .setWriteMode(this.getWriteMode())
-                .setBatchIntervalMs(this.getBatchIntervalMs());
+                .setBatchIntervalMs(this.getBatchIntervalMs())
+                .setFailureHandler(this.getFailureHandler())
+                .setMaxRetries(this.getMaxRetries());
     }
 
     public static class ExecutionOptionBuilder {
@@ -117,6 +122,8 @@ public class EdgeExecutionOptions extends ExecutionOptions {
         private int srcIndex = DEFAULT_ROW_INFO_INDEX;
         private int dstIndex = DEFAULT_ROW_INFO_INDEX;
         private int rankIndex = DEFAULT_ROW_INFO_INDEX;
+        private FailureHandlerEnum failureHandler = FailureHandlerEnum.IGNORE;
+        private int maxRetries = DEFAULT_EXECUTION_RETRY;
 
         public ExecutionOptionBuilder setGraphSpace(String graphSpace) {
             this.graphSpace = graphSpace;
@@ -205,6 +212,16 @@ public class EdgeExecutionOptions extends ExecutionOptions {
             return this;
         }
 
+        public ExecutionOptionBuilder setFailureHandler(FailureHandlerEnum failureHandler) {
+            this.failureHandler = failureHandler;
+            return this;
+        }
+
+        public ExecutionOptionBuilder setMaxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
         @Deprecated
         public EdgeExecutionOptions builder() {
             return build();
@@ -219,7 +236,7 @@ public class EdgeExecutionOptions extends ExecutionOptions {
             }
             return new EdgeExecutionOptions(graphSpace, executeStatement, fields, positions,
                     noColumn, limit, startTime, endTime, batchSize, policy, mode, edge, srcIndex,
-                    dstIndex, rankIndex, batchIntervalMs);
+                    dstIndex, rankIndex, batchIntervalMs, failureHandler, maxRetries);
         }
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/ExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/ExecutionOptions.java
@@ -147,6 +147,11 @@ public abstract class ExecutionOptions implements Serializable {
      */
     private int maxRetries;
 
+    /**
+     * retry delay
+     */
+    private int retryDelayMs;
+
     protected ExecutionOptions(String graphSpace,
                                String executeStatement,
                                List<String> fields,
@@ -160,7 +165,8 @@ public abstract class ExecutionOptions implements Serializable {
                                WriteModeEnum writeMode,
                                int batchIntervalMs,
                                FailureHandlerEnum failureHandler,
-                               int maxRetries) {
+                               int maxRetries,
+                               int retryDelayMs) {
         this.graphSpace = graphSpace;
         this.executeStatement = executeStatement;
         this.fields = fields;
@@ -175,6 +181,7 @@ public abstract class ExecutionOptions implements Serializable {
         this.batchIntervalMs = batchIntervalMs;
         this.failureHandler = failureHandler;
         this.maxRetries = maxRetries;
+        this.retryDelayMs = retryDelayMs;
     }
 
     public String getGraphSpace() {
@@ -242,6 +249,10 @@ public abstract class ExecutionOptions implements Serializable {
         return maxRetries;
     }
 
+    public int getRetryDelayMs() {
+        return retryDelayMs;
+    }
+
     @Override
     public String toString() {
         return "ExecutionOptions{"
@@ -259,6 +270,7 @@ public abstract class ExecutionOptions implements Serializable {
                 + ", batchIntervalMs=" + batchIntervalMs
                 + ", failureHandler=" + failureHandler
                 + ", maxRetries=" + maxRetries
+                + ", retryDelayMs=" + retryDelayMs
                 + '}';
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/ExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/ExecutionOptions.java
@@ -8,6 +8,7 @@ package org.apache.flink.connector.nebula.statement;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.flink.connector.nebula.utils.DataTypeEnum;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.PolicyEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
@@ -136,6 +137,15 @@ public abstract class ExecutionOptions implements Serializable {
      */
     private int batchIntervalMs;
 
+    /**
+     * failure handler
+     */
+    private FailureHandlerEnum failureHandler;
+
+    /**
+     * maximum number of retries
+     */
+    private int maxRetries;
 
     protected ExecutionOptions(String graphSpace,
                                String executeStatement,
@@ -148,7 +158,9 @@ public abstract class ExecutionOptions implements Serializable {
                                int batchSize,
                                PolicyEnum policy,
                                WriteModeEnum writeMode,
-                               int batchIntervalMs) {
+                               int batchIntervalMs,
+                               FailureHandlerEnum failureHandler,
+                               int maxRetries) {
         this.graphSpace = graphSpace;
         this.executeStatement = executeStatement;
         this.fields = fields;
@@ -161,6 +173,8 @@ public abstract class ExecutionOptions implements Serializable {
         this.policy = policy;
         this.writeMode = writeMode;
         this.batchIntervalMs = batchIntervalMs;
+        this.failureHandler = failureHandler;
+        this.maxRetries = maxRetries;
     }
 
     public String getGraphSpace() {
@@ -220,6 +234,14 @@ public abstract class ExecutionOptions implements Serializable {
         return batchIntervalMs;
     }
 
+    public FailureHandlerEnum getFailureHandler() {
+        return failureHandler;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
     @Override
     public String toString() {
         return "ExecutionOptions{"
@@ -235,6 +257,8 @@ public abstract class ExecutionOptions implements Serializable {
                 + ", policy=" + policy
                 + ", mode=" + writeMode
                 + ", batchIntervalMs=" + batchIntervalMs
+                + ", failureHandler=" + failureHandler
+                + ", maxRetries=" + maxRetries
                 + '}';
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/VertexExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/VertexExecutionOptions.java
@@ -6,6 +6,7 @@
 package org.apache.flink.connector.nebula.statement;
 
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_BATCH_INTERVAL_MS;
+import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_EXECUTION_RETRY;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_ROW_INFO_INDEX;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_SCAN_LIMIT;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_WRITE_BATCH_SIZE;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.flink.connector.nebula.utils.DataTypeEnum;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.PolicyEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 
@@ -42,9 +44,11 @@ public class VertexExecutionOptions extends ExecutionOptions {
                                   WriteModeEnum mode,
                                   String tag,
                                   int idIndex,
-                                  int batchIntervalMs) {
+                                  int batchIntervalMs,
+                                  FailureHandlerEnum failureHandler,
+                                  int maxRetries) {
         super(graphSpace, executeStatement, fields, positions, noColumn, limit, startTime,
-                endTime, batch, policy, mode, batchIntervalMs);
+                endTime, batch, policy, mode, batchIntervalMs, failureHandler, maxRetries);
         this.tag = tag;
         this.idIndex = idIndex;
     }
@@ -79,7 +83,9 @@ public class VertexExecutionOptions extends ExecutionOptions {
                         .map(Objects::toString).orElse(null))
                 .setIdIndex(this.getIdIndex())
                 .setWriteMode(this.getWriteMode())
-                .setBatchIntervalMs(this.getBatchIntervalMs());
+                .setBatchIntervalMs(this.getBatchIntervalMs())
+                .setFailureHandler(this.getFailureHandler())
+                .setMaxRetries(this.getMaxRetries());
     }
 
     public static class ExecutionOptionBuilder {
@@ -97,6 +103,8 @@ public class VertexExecutionOptions extends ExecutionOptions {
         private PolicyEnum policy = null;
         private WriteModeEnum mode = WriteModeEnum.INSERT;
         private int idIndex = DEFAULT_ROW_INFO_INDEX;
+        private FailureHandlerEnum failureHandler = FailureHandlerEnum.IGNORE;
+        private int maxRetries = DEFAULT_EXECUTION_RETRY;
 
         public ExecutionOptionBuilder setGraphSpace(String graphSpace) {
             this.graphSpace = graphSpace;
@@ -178,6 +186,16 @@ public class VertexExecutionOptions extends ExecutionOptions {
             return this;
         }
 
+        public ExecutionOptionBuilder setFailureHandler(FailureHandlerEnum failureHandler) {
+            this.failureHandler = failureHandler;
+            return this;
+        }
+
+        public ExecutionOptionBuilder setMaxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
         @Deprecated
         public VertexExecutionOptions builder() {
             return build();
@@ -192,7 +210,7 @@ public class VertexExecutionOptions extends ExecutionOptions {
             }
             return new VertexExecutionOptions(graphSpace, executeStatement, fields,
                     positions, noColumn, limit, startTime, endTime, batchSize, policy, mode, tag,
-                    idIndex, batchIntervalMs);
+                    idIndex, batchIntervalMs, failureHandler, maxRetries);
         }
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/statement/VertexExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/statement/VertexExecutionOptions.java
@@ -7,6 +7,7 @@ package org.apache.flink.connector.nebula.statement;
 
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_BATCH_INTERVAL_MS;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_EXECUTION_RETRY;
+import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_RETRY_DELAY_MS;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_ROW_INFO_INDEX;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_SCAN_LIMIT;
 import static org.apache.flink.connector.nebula.utils.NebulaConstant.DEFAULT_WRITE_BATCH_SIZE;
@@ -46,9 +47,11 @@ public class VertexExecutionOptions extends ExecutionOptions {
                                   int idIndex,
                                   int batchIntervalMs,
                                   FailureHandlerEnum failureHandler,
-                                  int maxRetries) {
+                                  int maxRetries,
+                                  int retryDelayMs) {
         super(graphSpace, executeStatement, fields, positions, noColumn, limit, startTime,
-                endTime, batch, policy, mode, batchIntervalMs, failureHandler, maxRetries);
+                endTime, batch, policy, mode, batchIntervalMs,
+                failureHandler, maxRetries, retryDelayMs);
         this.tag = tag;
         this.idIndex = idIndex;
     }
@@ -85,7 +88,8 @@ public class VertexExecutionOptions extends ExecutionOptions {
                 .setWriteMode(this.getWriteMode())
                 .setBatchIntervalMs(this.getBatchIntervalMs())
                 .setFailureHandler(this.getFailureHandler())
-                .setMaxRetries(this.getMaxRetries());
+                .setMaxRetries(this.getMaxRetries())
+                .setRetryDelayMs(this.getRetryDelayMs());
     }
 
     public static class ExecutionOptionBuilder {
@@ -105,6 +109,7 @@ public class VertexExecutionOptions extends ExecutionOptions {
         private int idIndex = DEFAULT_ROW_INFO_INDEX;
         private FailureHandlerEnum failureHandler = FailureHandlerEnum.IGNORE;
         private int maxRetries = DEFAULT_EXECUTION_RETRY;
+        private int retryDelayMs = DEFAULT_RETRY_DELAY_MS;
 
         public ExecutionOptionBuilder setGraphSpace(String graphSpace) {
             this.graphSpace = graphSpace;
@@ -196,6 +201,11 @@ public class VertexExecutionOptions extends ExecutionOptions {
             return this;
         }
 
+        public ExecutionOptionBuilder setRetryDelayMs(int retryDelayMs) {
+            this.retryDelayMs = retryDelayMs;
+            return this;
+        }
+
         @Deprecated
         public VertexExecutionOptions builder() {
             return build();
@@ -210,7 +220,7 @@ public class VertexExecutionOptions extends ExecutionOptions {
             }
             return new VertexExecutionOptions(graphSpace, executeStatement, fields,
                     positions, noColumn, limit, startTime, endTime, batchSize, policy, mode, tag,
-                    idIndex, batchIntervalMs, failureHandler, maxRetries);
+                    idIndex, batchIntervalMs, failureHandler, maxRetries, retryDelayMs);
         }
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
@@ -130,6 +130,12 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
             .defaultValue(NebulaConstant.DEFAULT_EXECUTION_RETRY)
             .withDescription("maximum number of retries.");
 
+    public static final ConfigOption<Integer> RETRY_DELAY_MS = ConfigOptions
+            .key("retry-delay-ms")
+            .intType()
+            .defaultValue(NebulaConstant.DEFAULT_RETRY_DELAY_MS)
+            .withDescription("retry delay in milliseconds.");
+
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final FactoryUtil.TableFactoryHelper helper =
@@ -197,7 +203,8 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .setGraphSpace(config.get(GRAPH_SPACE))
                             .setTag(labelName)
                             .setFailureHandler(config.get(FAILURE_HANDLER))
-                            .setMaxRetries(config.get(MAX_RETRIES));
+                            .setMaxRetries(config.get(MAX_RETRIES))
+                            .setRetryDelayMs(config.get(RETRY_DELAY_MS));
             config.getOptional(BATCH_SIZE).ifPresent(builder::setBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::setBatchIntervalMs);
             return builder.build();
@@ -219,7 +226,8 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .setGraphSpace(config.get(GRAPH_SPACE))
                             .setEdge(labelName)
                             .setFailureHandler(config.get(FAILURE_HANDLER))
-                            .setMaxRetries(config.get(MAX_RETRIES));
+                            .setMaxRetries(config.get(MAX_RETRIES))
+                            .setRetryDelayMs(config.get(RETRY_DELAY_MS));
             config.getOptional(BATCH_SIZE).ifPresent(builder::setBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::setBatchIntervalMs);
             return builder.build();
@@ -256,6 +264,7 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
         set.add(BATCH_INTERVAL_MS);
         set.add(FAILURE_HANDLER);
         set.add(MAX_RETRIES);
+        set.add(RETRY_DELAY_MS);
         return set;
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
@@ -173,6 +173,7 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                 .setGraphAddress(config.get(GRAPHADDRESS))
                 .setUsername(config.get(USERNAME))
                 .setPassword(config.get(PASSWORD))
+                .setTimeout(config.get(TIMEOUT))
                 .build();
     }
 

--- a/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
@@ -17,6 +17,7 @@ import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
 import org.apache.flink.connector.nebula.statement.ExecutionOptions;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
 import org.apache.flink.connector.nebula.utils.DataTypeEnum;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.NebulaConstant;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Column;
@@ -117,6 +118,18 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
             .noDefaultValue()
             .withDescription("batch commit interval in milliseconds.");
 
+    public static final ConfigOption<FailureHandlerEnum> FAILURE_HANDLER = ConfigOptions
+            .key("failure-handler")
+            .enumType(FailureHandlerEnum.class)
+            .defaultValue(FailureHandlerEnum.IGNORE)
+            .withDescription("failure handler.");
+
+    public static final ConfigOption<Integer> MAX_RETRIES = ConfigOptions
+            .key("max-retries")
+            .intType()
+            .defaultValue(NebulaConstant.DEFAULT_EXECUTION_RETRY)
+            .withDescription("maximum number of retries.");
+
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final FactoryUtil.TableFactoryHelper helper =
@@ -181,7 +194,9 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .setIdIndex(config.get(ID_INDEX))
                             .setPositions(positions)
                             .setGraphSpace(config.get(GRAPH_SPACE))
-                            .setTag(labelName);
+                            .setTag(labelName)
+                            .setFailureHandler(config.get(FAILURE_HANDLER))
+                            .setMaxRetries(config.get(MAX_RETRIES));
             config.getOptional(BATCH_SIZE).ifPresent(builder::setBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::setBatchIntervalMs);
             return builder.build();
@@ -201,7 +216,9 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .setRankIndex(config.get(RANK_ID_INDEX))
                             .setPositions(positions)
                             .setGraphSpace(config.get(GRAPH_SPACE))
-                            .setEdge(labelName);
+                            .setEdge(labelName)
+                            .setFailureHandler(config.get(FAILURE_HANDLER))
+                            .setMaxRetries(config.get(MAX_RETRIES));
             config.getOptional(BATCH_SIZE).ifPresent(builder::setBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::setBatchIntervalMs);
             return builder.build();
@@ -236,6 +253,8 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
         set.add(RANK_ID_INDEX);
         set.add(BATCH_SIZE);
         set.add(BATCH_INTERVAL_MS);
+        set.add(FAILURE_HANDLER);
+        set.add(MAX_RETRIES);
         return set;
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableSink.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableSink.java
@@ -18,20 +18,13 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
 
 public class NebulaDynamicTableSink implements DynamicTableSink {
-    private final String metaAddress;
-    private final String graphAddress;
-
-    private final String username;
-    private final String password;
+    private final NebulaClientOptions nebulaClientOptions;
     private final ExecutionOptions executionOptions;
     final DataType producedDataType;
 
     public NebulaDynamicTableSink(NebulaClientOptions clientOptions,
                                   ExecutionOptions executionOptions, DataType producedDataType) {
-        this.metaAddress = clientOptions.getRawMetaAddress();
-        this.graphAddress = clientOptions.getGraphAddress();
-        this.username = clientOptions.getUsername();
-        this.password = clientOptions.getPassword();
+        this.nebulaClientOptions = clientOptions;
         this.executionOptions = executionOptions;
         this.producedDataType = producedDataType;
     }
@@ -50,15 +43,10 @@ public class NebulaDynamicTableSink implements DynamicTableSink {
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
 
-        NebulaClientOptions builder = new NebulaClientOptions.NebulaClientOptionsBuilder()
-                .setMetaAddress(metaAddress)
-                .setGraphAddress(graphAddress)
-                .setUsername(username)
-                .setPassword(password)
-                .build();
-
-        NebulaGraphConnectionProvider graphProvider = new NebulaGraphConnectionProvider(builder);
-        NebulaMetaConnectionProvider metaProvider = new NebulaMetaConnectionProvider(builder);
+        NebulaGraphConnectionProvider graphProvider =
+                new NebulaGraphConnectionProvider(nebulaClientOptions);
+        NebulaMetaConnectionProvider metaProvider =
+                new NebulaMetaConnectionProvider(nebulaClientOptions);
         DataStructureConverter converter =
                 context.createDataStructureConverter(producedDataType);
         NebulaBatchOutputFormat<RowData, ?> outputFormat;

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/FailureHandlerEnum.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/FailureHandlerEnum.java
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package org.apache.flink.connector.nebula.utils;
+
+public enum FailureHandlerEnum {
+    FAIL("FAIL"),
+
+    IGNORE("IGNORE");
+
+    private final String handler;
+
+    FailureHandlerEnum(String handler) {
+        this.handler = handler;
+    }
+}

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaConstant.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaConstant.java
@@ -48,6 +48,7 @@ public class NebulaConstant {
     public static final int DEFAULT_CONNECT_TIMEOUT_MS = 3000;
     public static final int DEFAULT_CONNECT_RETRY = 3;
     public static final int DEFAULT_EXECUTION_RETRY = 3;
+    public static final int EXECUTION_RETRY_WAIT_INCREMENT_MS = 1000;
 
     // params for create space
     public static final String CREATE_VID_TYPE = "vid_type";

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaConstant.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaConstant.java
@@ -48,7 +48,7 @@ public class NebulaConstant {
     public static final int DEFAULT_CONNECT_TIMEOUT_MS = 3000;
     public static final int DEFAULT_CONNECT_RETRY = 3;
     public static final int DEFAULT_EXECUTION_RETRY = 3;
-    public static final int EXECUTION_RETRY_WAIT_INCREMENT_MS = 1000;
+    public static final int DEFAULT_RETRY_DELAY_MS = 1000;
 
     // params for create space
     public static final String CREATE_VID_TYPE = "vid_type";

--- a/connector/src/test/java/org/apache/flink/connector/nebula/MockData.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/MockData.java
@@ -8,7 +8,8 @@ package org.apache.flink.connector.nebula;
 public class MockData {
 
     public static String createStringSpace() {
-        return "CREATE SPACE IF NOT EXISTS test_string(partition_num=10,"
+        return "CLEAR SPACE IF EXISTS `test_string`;"
+                + "CREATE SPACE IF NOT EXISTS test_string(partition_num=10,"
                 + "vid_type=fixed_string(8));"
                 + "USE test_string;"
                 + "CREATE TAG IF NOT EXISTS person(col1 fixed_string(8), col2 string, col3 int32,"
@@ -18,7 +19,8 @@ public class MockData {
     }
 
     public static String createIntSpace() {
-        return "CREATE SPACE IF NOT EXISTS test_int(partition_num=10,vid_type=int64);"
+        return "CLEAR SPACE IF EXISTS `test_int`;"
+                + "CREATE SPACE IF NOT EXISTS test_int(partition_num=10,vid_type=int64);"
                 + "USE test_int;"
                 + "CREATE TAG IF NOT EXISTS person(col1 fixed_string(8), col2 string, col3 int32,"
                 + " col4 double, col5 date, col6 datetime, col7 time, col8 timestamp);"
@@ -27,10 +29,12 @@ public class MockData {
     }
 
     public static String createFlinkSinkSpace() {
-        return "CREATE SPACE IF NOT EXISTS flink_sink(partition_num=10,"
+        return "CLEAR SPACE IF EXISTS `flink_sink`;"
+                + "CREATE SPACE IF NOT EXISTS flink_sink(partition_num=10,"
                 + "vid_type=fixed_string(8));"
                 + "USE flink_sink;"
-                + "CREATE TAG IF NOT EXISTS player(name string, age int);";
+                + "CREATE TAG IF NOT EXISTS player(name string, age int);"
+                + "CREATE EDGE IF NOT EXISTS follow(degree int);";
     }
 
     public static String createFlinkTestSpace() {

--- a/connector/src/test/java/org/apache/flink/connector/nebula/connection/NebulaGraphConnectionProviderTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/connection/NebulaGraphConnectionProviderTest.java
@@ -47,13 +47,13 @@ public class NebulaGraphConnectionProviderTest {
             NebulaPool nebulaPool = graphConnectionProvider.getNebulaPool();
             nebulaPool.getSession("root", "nebula", true);
         } catch (Exception e) {
-            LOG.info("get session failed, ", e);
+            LOG.info("get session failed", e);
             assert (false);
         }
     }
 
     /**
-     * nebula server does not enable ssl, the connect cannot be established correctly.
+     * nebula server does not enable ssl, the connection cannot be established correctly.
      */
     @Test(expected = NotValidConnectionException.class)
     public void getSessionWithSsl() throws NotValidConnectionException {
@@ -82,7 +82,7 @@ public class NebulaGraphConnectionProviderTest {
             pool.getSession("root", "nebula", true);
         } catch (UnknownHostException | IOErrorException | AuthFailedException
                 | ClientServerIncompatibleException e) {
-            LOG.error("get session faied, ", e);
+            LOG.error("get session failed", e);
             assert (false);
         }
     }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
@@ -12,7 +12,6 @@ import static org.apache.flink.connector.nebula.NebulaValueUtils.rowOf;
 import static org.apache.flink.connector.nebula.NebulaValueUtils.timeOf;
 import static org.apache.flink.connector.nebula.NebulaValueUtils.valueOf;
 
-import com.vesoft.nebula.client.graph.exception.IOErrorException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -40,6 +39,9 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
             LoggerFactory.getLogger(AbstractNebulaOutputFormatITTest.class);
 
     private static TableEnvironment tableEnvironment;
+
+    class FlinkTestException extends Exception {
+    }
 
     @BeforeClass
     public static void beforeAll() {
@@ -157,6 +159,67 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + " ORDER BY key LIMIT 10"
         );
 
+    }
+
+    private void runSinkVertexInvalid(String failureHandler)
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        Configuration configuration = tableEnvironment.getConfig().getConfiguration();
+        configuration.setString("table.dml-sync", "true");
+
+        tableEnvironment.executeSql(
+                "CREATE TABLE person_fail ("
+                        + "vid STRING,"
+                        + "col5 STRING"
+                        + ")"
+                        + "WITH ("
+                        + "'connector'='nebula',"
+                        + "'meta-address'='"
+                        + META_ADDRESS
+                        + "',"
+                        + "'graph-address'='"
+                        + GRAPH_ADDRESS
+                        + "',"
+                        + "'username'='"
+                        + USERNAME
+                        + "',"
+                        + "'password'='"
+                        + PASSWORD
+                        + "',"
+                        + "'graph-space'='flink_test',"
+                        + "'label-name'='person',"
+                        + "'data-type'='vertex',"
+                        + "'failure-handler'='"
+                        + failureHandler
+                        + "',"
+                        + "'max-retries'='0'"
+                        + ")"
+        );
+
+        try {
+            tableEnvironment.executeSql(
+                    "INSERT INTO person_fail VALUES ('61', 'abc')"
+            ).await();
+        } catch (RuntimeException e) {
+            throw new FlinkTestException();
+        }
+    }
+
+    /**
+     * sink Nebula Graph Vertex Data and fail with error
+     */
+    @Test(expected = FlinkTestException.class)
+    public void testSinkVertexDataFailInvalid()
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        runSinkVertexInvalid("fail");
+    }
+
+    /**
+     * sink Nebula Graph Vertex Data and ignore error
+     */
+    @Test
+    public void testSinkVertexDataIgnoreInvalid()
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        runSinkVertexInvalid("ignore");
     }
 
     @Test
@@ -410,6 +473,70 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + " r.col8, r.col9, r.col10, r.col11, r.col12, r.col13, r.col14"
                         + " LIMIT 10"
         );
+    }
+
+    private void runSinkEdgeInvalid(String failureHandler)
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        Configuration configuration = tableEnvironment.getConfig().getConfiguration();
+        configuration.setString("table.dml-sync", "true");
+
+        tableEnvironment.executeSql(
+                "CREATE TABLE friend_fail ("
+                        + "src STRING,"
+                        + "dst STRING,"
+                        + "col5 STRING"
+                        + ")"
+                        + "WITH ("
+                        + "'connector'='nebula',"
+                        + "'meta-address'='"
+                        + META_ADDRESS
+                        + "',"
+                        + "'graph-address'='"
+                        + GRAPH_ADDRESS
+                        + "',"
+                        + "'username'='"
+                        + USERNAME
+                        + "',"
+                        + "'password'='"
+                        + PASSWORD
+                        + "',"
+                        + "'graph-space'='flink_test',"
+                        + "'label-name'='friend',"
+                        + "'src-id-index'='0',"
+                        + "'dst-id-index'='1',"
+                        + "'data-type'='edge',"
+                        + "'failure-handler'='"
+                        + failureHandler
+                        + "',"
+                        + "'max-retries'='0'"
+                        + ")"
+        );
+
+        try {
+            tableEnvironment.executeSql(
+                    "INSERT INTO friend_fail VALUES ('61', '62', 'abc')"
+            ).await();
+        } catch (RuntimeException e) {
+            throw new FlinkTestException();
+        }
+    }
+
+    /**
+     * sink Nebula Graph Edge Data and fail with error
+     */
+    @Test(expected = FlinkTestException.class)
+    public void testSinkEdgeDataFailInvalid()
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        runSinkEdgeInvalid("fail");
+    }
+
+    /**
+     * sink Nebula Graph Edge Data and ignore error
+     */
+    @Test
+    public void testSinkEdgeDataIgnoreInvalid()
+            throws ExecutionException, InterruptedException, FlinkTestException {
+        runSinkEdgeInvalid("ignore");
     }
 
     @Test

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatITTest.java
@@ -40,7 +40,10 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
 
     private static TableEnvironment tableEnvironment;
 
-    class FlinkTestException extends Exception {
+    static class FlinkJobException extends RuntimeException {
+        public FlinkJobException(Throwable cause) {
+            super(cause);
+        }
     }
 
     @BeforeClass
@@ -162,7 +165,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
     }
 
     private void runSinkVertexInvalid(String failureHandler)
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         Configuration configuration = tableEnvironment.getConfig().getConfiguration();
         configuration.setString("table.dml-sync", "true");
 
@@ -191,7 +194,8 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + "'failure-handler'='"
                         + failureHandler
                         + "',"
-                        + "'max-retries'='0'"
+                        + "'max-retries'='0',"
+                        + "'retry-delay-ms'='100'"
                         + ")"
         );
 
@@ -199,17 +203,17 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
             tableEnvironment.executeSql(
                     "INSERT INTO person_fail VALUES ('61', 'abc')"
             ).await();
-        } catch (RuntimeException e) {
-            throw new FlinkTestException();
+        } catch (Exception e) {
+            throw new FlinkJobException(e);
         }
     }
 
     /**
      * sink Nebula Graph Vertex Data and fail with error
      */
-    @Test(expected = FlinkTestException.class)
+    @Test(expected = FlinkJobException.class)
     public void testSinkVertexDataFailInvalid()
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         runSinkVertexInvalid("fail");
     }
 
@@ -218,7 +222,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
      */
     @Test
     public void testSinkVertexDataIgnoreInvalid()
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         runSinkVertexInvalid("ignore");
     }
 
@@ -476,7 +480,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
     }
 
     private void runSinkEdgeInvalid(String failureHandler)
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         Configuration configuration = tableEnvironment.getConfig().getConfiguration();
         configuration.setString("table.dml-sync", "true");
 
@@ -508,7 +512,8 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
                         + "'failure-handler'='"
                         + failureHandler
                         + "',"
-                        + "'max-retries'='0'"
+                        + "'max-retries'='0',"
+                        + "'retry-delay-ms'='100'"
                         + ")"
         );
 
@@ -516,17 +521,17 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
             tableEnvironment.executeSql(
                     "INSERT INTO friend_fail VALUES ('61', '62', 'abc')"
             ).await();
-        } catch (RuntimeException e) {
-            throw new FlinkTestException();
+        } catch (Exception e) {
+            throw new FlinkJobException(e);
         }
     }
 
     /**
      * sink Nebula Graph Edge Data and fail with error
      */
-    @Test(expected = FlinkTestException.class)
+    @Test(expected = FlinkJobException.class)
     public void testSinkEdgeDataFailInvalid()
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         runSinkEdgeInvalid("fail");
     }
 
@@ -535,7 +540,7 @@ public class AbstractNebulaOutputFormatITTest extends NebulaITTestBase {
      */
     @Test
     public void testSinkEdgeDataIgnoreInvalid()
-            throws ExecutionException, InterruptedException, FlinkTestException {
+            throws ExecutionException, InterruptedException {
         runSinkEdgeInvalid("ignore");
     }
 

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/AbstractNebulaOutputFormatTest.java
@@ -5,17 +5,23 @@
 
 package org.apache.flink.connector.nebula.sink;
 
+import static org.apache.flink.connector.nebula.NebulaValueUtils.rowOf;
+import static org.apache.flink.connector.nebula.NebulaValueUtils.valueOf;
+
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.connection.NebulaClientOptions;
 import org.apache.flink.connector.nebula.connection.NebulaGraphConnectionProvider;
 import org.apache.flink.connector.nebula.connection.NebulaMetaConnectionProvider;
+import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
+import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -24,6 +30,11 @@ import org.slf4j.LoggerFactory;
 public class AbstractNebulaOutputFormatTest extends NebulaITTestBase {
     private static final Logger LOGGER =
             LoggerFactory.getLogger(AbstractNebulaOutputFormatTest.class);
+
+    private NebulaGraphConnectionProvider graphProvider;
+    private NebulaMetaConnectionProvider metaProvider;
+    private VertexExecutionOptions.ExecutionOptionBuilder vertexExecutionOptionBuilder = null;
+    private EdgeExecutionOptions.ExecutionOptionBuilder edgeExecutionOptionBuilder = null;
 
     @BeforeClass
     public static void beforeAll() {
@@ -36,36 +47,176 @@ public class AbstractNebulaOutputFormatTest extends NebulaITTestBase {
         closeNebulaSession();
     }
 
-    @Test
-    public void testWrite() throws IOException {
-        List<String> cols = Arrays.asList("name", "age");
-        VertexExecutionOptions executionOptions =
-                new VertexExecutionOptions.ExecutionOptionBuilder()
-                        .setGraphSpace("flink_sink")
-                        .setTag("player")
-                        .setFields(cols)
-                        .setPositions(Arrays.asList(1, 2))
-                        .setIdIndex(0)
-                        .setBatchSize(1)
-                        .build();
-
+    @Before
+    public void before() {
         NebulaClientOptions clientOptions = new NebulaClientOptions
                 .NebulaClientOptionsBuilder()
                 .setMetaAddress(META_ADDRESS)
                 .setGraphAddress(GRAPH_ADDRESS)
                 .build();
-        NebulaGraphConnectionProvider graphProvider =
+        graphProvider =
                 new NebulaGraphConnectionProvider(clientOptions);
-        NebulaMetaConnectionProvider metaProvider = new NebulaMetaConnectionProvider(clientOptions);
-        Row row = new Row(3);
-        row.setField(0, 111);
+        metaProvider = new NebulaMetaConnectionProvider(clientOptions);
+        vertexExecutionOptionBuilder = new VertexExecutionOptions.ExecutionOptionBuilder()
+                .setGraphSpace("flink_sink")
+                .setTag("player")
+                .setFields(Arrays.asList("name", "age"))
+                .setPositions(Arrays.asList(1, 2))
+                .setIdIndex(0)
+                .setBatchSize(1);
+        edgeExecutionOptionBuilder = new EdgeExecutionOptions.ExecutionOptionBuilder()
+                .setGraphSpace("flink_sink")
+                .setEdge("follow")
+                .setFields(Arrays.asList("degree"))
+                .setPositions(Arrays.asList(2))
+                .setSrcIndex(0)
+                .setDstIndex(1)
+                .setBatchSize(1);
+    }
+
+    @SafeVarargs
+    private static <T> void writeRecords(
+            NebulaBatchOutputFormat<T, ?> outputFormat, T... row) throws IOException {
+        outputFormat.open(1, 2);
+        try {
+            for (T r : row) {
+                outputFormat.writeRecord(r);
+            }
+        } finally {
+            outputFormat.close();
+        }
+    }
+
+    @Test
+    public void testWriteVertex() throws IOException {
+        final VertexExecutionOptions options = vertexExecutionOptionBuilder.build();
+        final NebulaVertexBatchOutputFormat outputFormat =
+                new NebulaVertexBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row = new Row(3);
+        row.setField(0, "111");
         row.setField(1, "jena");
         row.setField(2, 12);
 
-        NebulaVertexBatchOutputFormat outputFormat =
-                new NebulaVertexBatchOutputFormat(graphProvider, metaProvider, executionOptions);
-
-        outputFormat.open(1, 2);
-        outputFormat.writeRecord(row);
+        writeRecords(outputFormat, row);
+        executeNGql("USE flink_sink");
+        check(
+                Arrays.asList(rowOf(valueOf(12))),
+                "MATCH (n) WHERE id(n) == \"111\" RETURN n.player.age"
+        );
     }
+
+    @Test(expected = IOException.class)
+    public void testWriteVertexFailInvalid() throws IOException {
+        final VertexExecutionOptions options = vertexExecutionOptionBuilder
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.FAIL)
+                .setMaxRetries(2)
+                .setRetryDelayMs(100)
+                .build();
+        final NebulaVertexBatchOutputFormat outputFormat =
+                new NebulaVertexBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row = new Row(3);
+        row.setField(0, "222");
+        row.setField(1, "jena");
+        row.setField(2, "abc");
+
+        writeRecords(outputFormat, row);
+    }
+
+    @Test
+    public void testWriteVertexIgnoreInvalid() throws IOException {
+        final VertexExecutionOptions options = vertexExecutionOptionBuilder
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.IGNORE)
+                .setMaxRetries(2)
+                .setRetryDelayMs(100)
+                .build();
+        final NebulaVertexBatchOutputFormat outputFormat =
+                new NebulaVertexBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row1 = new Row(3);
+        row1.setField(0, "222");
+        row1.setField(1, "jena");
+        row1.setField(2, "abc");
+        final Row row2 = new Row(3);
+        row2.setField(0, "222");
+        row2.setField(1, "jena");
+        row2.setField(2, 15);
+
+        writeRecords(outputFormat, row1, row2);
+        executeNGql("USE flink_sink");
+        check(
+                Arrays.asList(rowOf(valueOf(15))),
+                "MATCH (n) WHERE id(n) == \"222\" RETURN n.player.age"
+        );
+    }
+
+    @Test
+    public void testWriteEdge() throws IOException {
+        final EdgeExecutionOptions options = edgeExecutionOptionBuilder.build();
+        final NebulaEdgeBatchOutputFormat outputFormat =
+                new NebulaEdgeBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row = new Row(3);
+        row.setField(0, "111");
+        row.setField(1, "333");
+        row.setField(2, 20);
+
+        writeRecords(outputFormat, row);
+        executeNGql("USE flink_sink");
+        check(
+                Arrays.asList(rowOf(valueOf(20))),
+                "GO FROM \"111\" OVER follow YIELD properties(edge).degree"
+        );
+    }
+
+    @Test(expected = IOException.class)
+    public void testWriteEdgeFailInvalid() throws IOException {
+        final EdgeExecutionOptions options = edgeExecutionOptionBuilder
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.FAIL)
+                .setMaxRetries(2)
+                .setRetryDelayMs(100)
+                .build();
+        final NebulaEdgeBatchOutputFormat outputFormat =
+                new NebulaEdgeBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row = new Row(3);
+        row.setField(0, "222");
+        row.setField(1, "333");
+        row.setField(2, "abc");
+
+        writeRecords(outputFormat, row);
+    }
+
+    @Test
+    public void testWriteEdgeIgnoreInvalid() throws IOException {
+        final EdgeExecutionOptions options = edgeExecutionOptionBuilder
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.IGNORE)
+                .setMaxRetries(2)
+                .setRetryDelayMs(100)
+                .build();
+        final NebulaEdgeBatchOutputFormat outputFormat =
+                new NebulaEdgeBatchOutputFormat(graphProvider, metaProvider, options);
+
+        final Row row1 = new Row(3);
+        row1.setField(0, "222");
+        row1.setField(1, "333");
+        row1.setField(2, "abc");
+        final Row row2 = new Row(3);
+        row2.setField(0, "222");
+        row2.setField(1, "333");
+        row2.setField(2, 25);
+
+        writeRecords(outputFormat, row1, row2);
+        executeNGql("USE flink_sink");
+        check(
+                Arrays.asList(rowOf(valueOf(25))),
+                "GO FROM \"222\" OVER follow YIELD properties(edge).degree"
+        );
+    }
+
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
@@ -189,12 +190,11 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         edgeBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for int vid and UPDATE mode
+     * test batch execute for int vid and UPDATE mode
      */
     @Test
     public void testExecuteBatchWithUpdate() {
@@ -210,12 +210,11 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         edgeBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for int vid and DELETE mode
+     * test batch execute for int vid and DELETE mode
      */
     @Test
     public void testExecuteBatchWithDelete() {
@@ -229,12 +228,50 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         edgeBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for string vid and insert mode
+     * test batch execute with invalid data and fail
+     */
+    @Test(expected = RuntimeException.class)
+    public void testExecuteBatchFailInvalid() {
+        EdgeExecutionOptions options = builder.setGraphSpace("test_int")
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.FAIL)
+                .build();
+        NebulaEdgeBatchExecutor edgeBatchExecutor =
+                new NebulaEdgeBatchExecutor(options, VidTypeEnum.INT, schema);
+        Row row = Row.copy(row1);
+        row.setField(4, "abc");
+        edgeBatchExecutor.addToBatch(row);
+
+        executeNGql("USE test_int");
+        edgeBatchExecutor.executeBatch(session);
+    }
+
+    /**
+     * test batch execute with invalid data and ignore
+     */
+    @Test
+    public void testExecuteBatchIgnoreInvalid() {
+        EdgeExecutionOptions options = builder.setGraphSpace("test_int")
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.IGNORE)
+                .setMaxRetries(2)
+                .build();
+        NebulaEdgeBatchExecutor edgeBatchExecutor =
+                new NebulaEdgeBatchExecutor(options, VidTypeEnum.INT, schema);
+        Row row = Row.copy(row1);
+        row.setField(4, "abc");
+        edgeBatchExecutor.addToBatch(row);
+
+        executeNGql("USE test_int");
+        edgeBatchExecutor.executeBatch(session);
+    }
+
+    /**
+     * test batch execute for string vid and insert mode
      */
     @Test
     public void testExecuteBatchWithStringVidAndInsert() {
@@ -248,7 +285,6 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         edgeBatchExecutor.executeBatch(session);
     }
 
@@ -268,7 +304,6 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         edgeBatchExecutor.executeBatch(session);
     }
 
@@ -287,7 +322,6 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         edgeBatchExecutor.executeBatch(session);
     }
 

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
@@ -6,13 +6,13 @@
 package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.PropertyType;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
-import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
@@ -178,7 +178,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and insert mode
      */
     @Test
-    public void testExecuteBatch() {
+    public void testExecuteBatch() throws IOException {
         EdgeExecutionOptions options = builder
                 .setGraphSpace("test_int")
                 .setPolicy("HASH")
@@ -197,7 +197,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and UPDATE mode
      */
     @Test
-    public void testExecuteBatchWithUpdate() {
+    public void testExecuteBatchWithUpdate() throws IOException {
         testExecuteBatch();
         EdgeExecutionOptions options = builder
                 .setGraphSpace("test_int")
@@ -217,7 +217,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and DELETE mode
      */
     @Test
-    public void testExecuteBatchWithDelete() {
+    public void testExecuteBatchWithDelete() throws IOException {
         EdgeExecutionOptions options = builder.setGraphSpace("test_int")
                 .setPolicy("HASH")
                 .setWriteMode(WriteModeEnum.DELETE)
@@ -231,50 +231,12 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
         edgeBatchExecutor.executeBatch(session);
     }
 
-    /**
-     * test batch execute with invalid data and fail
-     */
-    @Test(expected = RuntimeException.class)
-    public void testExecuteBatchFailInvalid() {
-        EdgeExecutionOptions options = builder.setGraphSpace("test_int")
-                .setWriteMode(WriteModeEnum.INSERT)
-                .setFailureHandler(FailureHandlerEnum.FAIL)
-                .build();
-        NebulaEdgeBatchExecutor edgeBatchExecutor =
-                new NebulaEdgeBatchExecutor(options, VidTypeEnum.INT, schema);
-        Row row = Row.copy(row1);
-        row.setField(4, "abc");
-        edgeBatchExecutor.addToBatch(row);
-
-        executeNGql("USE test_int");
-        edgeBatchExecutor.executeBatch(session);
-    }
-
-    /**
-     * test batch execute with invalid data and ignore
-     */
-    @Test
-    public void testExecuteBatchIgnoreInvalid() {
-        EdgeExecutionOptions options = builder.setGraphSpace("test_int")
-                .setWriteMode(WriteModeEnum.INSERT)
-                .setFailureHandler(FailureHandlerEnum.IGNORE)
-                .setMaxRetries(2)
-                .build();
-        NebulaEdgeBatchExecutor edgeBatchExecutor =
-                new NebulaEdgeBatchExecutor(options, VidTypeEnum.INT, schema);
-        Row row = Row.copy(row1);
-        row.setField(4, "abc");
-        edgeBatchExecutor.addToBatch(row);
-
-        executeNGql("USE test_int");
-        edgeBatchExecutor.executeBatch(session);
-    }
 
     /**
      * test batch execute for string vid and insert mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndInsert() {
+    public void testExecuteBatchWithStringVidAndInsert() throws IOException {
         EdgeExecutionOptions options = builder
                 .setGraphSpace("test_string")
                 .setWriteMode(WriteModeEnum.INSERT)
@@ -292,7 +254,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for string vid and update mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndUpdate() {
+    public void testExecuteBatchWithStringVidAndUpdate() throws IOException {
         testExecuteBatchWithStringVidAndInsert();
         EdgeExecutionOptions options = builder
                 .setGraphSpace("test_string")
@@ -311,7 +273,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for string vid and DELETE mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndDelete() {
+    public void testExecuteBatchWithStringVidAndDelete() throws IOException {
         EdgeExecutionOptions options = builder
                 .setGraphSpace("test_string")
                 .setWriteMode(WriteModeEnum.DELETE)

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaEdgeBatchExecutorTest.java
@@ -190,8 +190,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -212,8 +211,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -232,8 +230,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -252,8 +249,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -273,8 +269,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -293,8 +288,7 @@ public class NebulaEdgeBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = edgeBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        edgeBatchExecutor.executeBatch(session);
     }
 
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaOutputFormatConverterTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaOutputFormatConverterTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.connector.nebula.statement.EdgeExecutionOptions;
-import org.apache.flink.connector.nebula.statement.ExecutionOptions;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
 import org.apache.flink.connector.nebula.utils.NebulaEdge;
 import org.apache.flink.connector.nebula.utils.NebulaVertex;

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
+import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
@@ -186,12 +187,11 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         vertexBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for int vid and UPDATE mode
+     * test batch execute for int vid and UPDATE mode
      */
     @Test
     public void testExecuteBatchWithUpdate() {
@@ -207,12 +207,11 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         vertexBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for int vid and DELETE mode
+     * test batch execute for int vid and DELETE mode
      */
     @Test
     public void testExecuteBatchWithDelete() {
@@ -226,12 +225,50 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_int");
-
         vertexBatchExecutor.executeBatch(session);
     }
 
     /**
-     * test batch exeucte for string vid and insert mode
+     * test batch execute with invalid data and fail
+     */
+    @Test(expected = RuntimeException.class)
+    public void testExecuteBatchFailInvalid() {
+        VertexExecutionOptions options = builder.setGraphSpace("test_int")
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.FAIL)
+                .build();
+        NebulaVertexBatchExecutor vertexBatchExecutor =
+                new NebulaVertexBatchExecutor(options, VidTypeEnum.INT, schema);
+        Row row = Row.copy(row1);
+        row.setField(3, "abc");
+        vertexBatchExecutor.addToBatch(row);
+
+        executeNGql("USE test_int");
+        vertexBatchExecutor.executeBatch(session);
+    }
+
+    /**
+     * test batch execute with invalid data and ignore
+     */
+    @Test
+    public void testExecuteBatchIgnoreInvalid() {
+        VertexExecutionOptions options = builder.setGraphSpace("test_int")
+                .setWriteMode(WriteModeEnum.INSERT)
+                .setFailureHandler(FailureHandlerEnum.IGNORE)
+                .setMaxRetries(2)
+                .build();
+        NebulaVertexBatchExecutor vertexBatchExecutor =
+                new NebulaVertexBatchExecutor(options, VidTypeEnum.INT, schema);
+        Row row = Row.copy(row1);
+        row.setField(3, "abc");
+        vertexBatchExecutor.addToBatch(row);
+
+        executeNGql("USE test_int");
+        vertexBatchExecutor.executeBatch(session);
+    }
+
+    /**
+     * test batch execute for string vid and insert mode
      */
     @Test
     public void testExecuteBatchWithStringVidAndInsert() {
@@ -245,7 +282,6 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         vertexBatchExecutor.executeBatch(session);
     }
 
@@ -265,7 +301,6 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         vertexBatchExecutor.executeBatch(session);
     }
 
@@ -284,7 +319,6 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
         vertexBatchExecutor.addToBatch(row2);
 
         executeNGql("USE test_string");
-
         vertexBatchExecutor.executeBatch(session);
     }
 

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
@@ -187,8 +187,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -209,8 +208,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -229,8 +227,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_int");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -249,8 +246,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -270,8 +266,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
     /**
@@ -290,8 +285,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
 
         executeNGql("USE test_string");
 
-        String statement = vertexBatchExecutor.executeBatch(session);
-        assert (statement == null);
+        vertexBatchExecutor.executeBatch(session);
     }
 
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaVertexBatchExecutorTest.java
@@ -6,13 +6,13 @@
 package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.PropertyType;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.flink.connector.nebula.MockData;
 import org.apache.flink.connector.nebula.NebulaITTestBase;
 import org.apache.flink.connector.nebula.statement.VertexExecutionOptions;
-import org.apache.flink.connector.nebula.utils.FailureHandlerEnum;
 import org.apache.flink.connector.nebula.utils.VidTypeEnum;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
 import org.apache.flink.types.Row;
@@ -175,7 +175,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and insert mode
      */
     @Test
-    public void testExecuteBatch() {
+    public void testExecuteBatch() throws IOException {
         VertexExecutionOptions options = builder
                 .setGraphSpace("test_int")
                 .setPolicy("HASH")
@@ -194,7 +194,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and UPDATE mode
      */
     @Test
-    public void testExecuteBatchWithUpdate() {
+    public void testExecuteBatchWithUpdate() throws IOException {
         testExecuteBatch();
         VertexExecutionOptions options = builder
                 .setGraphSpace("test_int")
@@ -214,7 +214,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for int vid and DELETE mode
      */
     @Test
-    public void testExecuteBatchWithDelete() {
+    public void testExecuteBatchWithDelete() throws IOException {
         VertexExecutionOptions options = builder.setGraphSpace("test_int")
                 .setPolicy("HASH")
                 .setWriteMode(WriteModeEnum.DELETE)
@@ -229,49 +229,10 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
     }
 
     /**
-     * test batch execute with invalid data and fail
-     */
-    @Test(expected = RuntimeException.class)
-    public void testExecuteBatchFailInvalid() {
-        VertexExecutionOptions options = builder.setGraphSpace("test_int")
-                .setWriteMode(WriteModeEnum.INSERT)
-                .setFailureHandler(FailureHandlerEnum.FAIL)
-                .build();
-        NebulaVertexBatchExecutor vertexBatchExecutor =
-                new NebulaVertexBatchExecutor(options, VidTypeEnum.INT, schema);
-        Row row = Row.copy(row1);
-        row.setField(3, "abc");
-        vertexBatchExecutor.addToBatch(row);
-
-        executeNGql("USE test_int");
-        vertexBatchExecutor.executeBatch(session);
-    }
-
-    /**
-     * test batch execute with invalid data and ignore
-     */
-    @Test
-    public void testExecuteBatchIgnoreInvalid() {
-        VertexExecutionOptions options = builder.setGraphSpace("test_int")
-                .setWriteMode(WriteModeEnum.INSERT)
-                .setFailureHandler(FailureHandlerEnum.IGNORE)
-                .setMaxRetries(2)
-                .build();
-        NebulaVertexBatchExecutor vertexBatchExecutor =
-                new NebulaVertexBatchExecutor(options, VidTypeEnum.INT, schema);
-        Row row = Row.copy(row1);
-        row.setField(3, "abc");
-        vertexBatchExecutor.addToBatch(row);
-
-        executeNGql("USE test_int");
-        vertexBatchExecutor.executeBatch(session);
-    }
-
-    /**
      * test batch execute for string vid and insert mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndInsert() {
+    public void testExecuteBatchWithStringVidAndInsert() throws IOException {
         VertexExecutionOptions options = builder
                 .setGraphSpace("test_string")
                 .setWriteMode(WriteModeEnum.INSERT)
@@ -289,7 +250,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for string vid and update mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndUpdate() {
+    public void testExecuteBatchWithStringVidAndUpdate() throws IOException {
         testExecuteBatchWithStringVidAndInsert();
         VertexExecutionOptions options = builder
                 .setGraphSpace("test_string")
@@ -308,7 +269,7 @@ public class NebulaVertexBatchExecutorTest extends NebulaITTestBase {
      * test batch execute for string vid and DELETE mode
      */
     @Test
-    public void testExecuteBatchWithStringVidAndDelete() {
+    public void testExecuteBatchWithStringVidAndDelete() throws IOException {
         VertexExecutionOptions options = builder
                 .setGraphSpace("test_string")
                 .setWriteMode(WriteModeEnum.DELETE)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?

#### Issue(s) number

N/A

#### Description

We have found a few edge cases when the connector does not handle failures gracefully. This PR tries to make the implementation more robust, based on our observations running the connector in production in the past few months.

## How do you solve it?

We have the following changes to the connector:
1. Support retries in the executor.
2. Support raising exceptions and letting the task fail fast when there are unrecoverable errors. (This behavior is configurable. See the following about the configuration.)
3. Support renewing the session when the execution fails. This fixes #83.
4. Do not return and store the error message from the `NebulaBatchExecutor.executeBatch()` method. This prevents Java heap memory to grow out-of-bound when there are a large number of correlated errors.
5. Polish various error messages in the log and exceptions.

We introduce three new options for the Table API connector:
* `max-retries`: Maximum number of retries in the execution. The default value is `3`.
* `retry-delay-ms`: The delay between retries, in milliseconds. The default value is `1000`.
* `failure-handler`: The failure handling mode when execution retries are exhausted. The valid values are (1) `ignore`, which skips the batch that fails; (2) `fail`, which fails the task. When the task fails, Flink may restart the task depending on how the job is configured. This also allows for detection and manual intervention when there is an unrecoverable error (due to corrupted data, unhealthy NebulaGraph cluster, bad network connection, etc.). The default value is `ignore`, which is consistent with the current implementation. So the option backward-compatible.

The DataStream connector can be configured similarly using `ExecutionOptions`.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

N/A