### PR TITLE
feat: support custom gql template execution for sink

### DIFF
--- a/connector/src/main/java/org.apache.flink/connector/nebula/options/ExecutionOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/options/ExecutionOptions.java
@@ -19,6 +19,7 @@ public class ExecutionOptions implements Serializable {
     private final int           retryTimes;
     private final long          intervalMs;
     private final boolean       errorWhenFailed;
+    private final String        gqlTemplate;
 
     protected ExecutionOptions(String graphName,
                                List<String> nebulaFields,
@@ -27,7 +28,8 @@ public class ExecutionOptions implements Serializable {
                                int batchSize,
                                int retryTimes,
                                long intervalMs,
-                               boolean errorWhenFailed) {
+                                boolean errorWhenFailed,
+                                String gqlTemplate) {
         this.graphName = graphName;
         this.nebulaFields = nebulaFields;
         this.flinkFields = flinkFields;
@@ -36,6 +38,7 @@ public class ExecutionOptions implements Serializable {
         this.retryTimes = retryTimes;
         this.intervalMs = intervalMs;
         this.errorWhenFailed = errorWhenFailed;
+        this.gqlTemplate = gqlTemplate;
     }
 
     public String getGraphName() {
@@ -68,5 +71,13 @@ public class ExecutionOptions implements Serializable {
 
     public boolean throwErrorWhenFailed() {
         return errorWhenFailed;
+    }
+
+    public String getGqlTemplate() {
+        return gqlTemplate;
+    }
+
+    public boolean hasCustomGqlTemplate() {
+        return gqlTemplate != null && !gqlTemplate.trim().isEmpty();
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/options/SinkEdgeOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/options/SinkEdgeOptions.java
@@ -34,7 +34,8 @@ public class SinkEdgeOptions extends ExecutionOptions {
               builder.batchSize,
               builder.retryTimes,
               builder.intervalMs,
-              builder.errorWhenFailed);
+              builder.errorWhenFailed,
+              builder.gqlTemplate);
         this.builder = builder;
         this.edgeType = builder.edgeType;
         this.nebulaSrcPks = builder.nebulaSrcPks;
@@ -87,6 +88,7 @@ public class SinkEdgeOptions extends ExecutionOptions {
         private int           retryTimes       = DEFAULT_RETRY_TIMES;
         private long          intervalMs       = DEFAULT_INTERVAL_MILLIS;
         private boolean       errorWhenFailed  = DEFAULT_ERROR_WHEN_FAILED;
+        private String        gqlTemplate;
 
 
         public Builder withGraphName(String graphName) {
@@ -159,6 +161,11 @@ public class SinkEdgeOptions extends ExecutionOptions {
 
         public Builder withErrorWhenFailed(boolean errorWhenFailed) {
             this.errorWhenFailed = errorWhenFailed;
+            return this;
+        }
+
+        public Builder withGqlTemplate(String gqlTemplate) {
+            this.gqlTemplate = gqlTemplate;
             return this;
         }
 

--- a/connector/src/main/java/org.apache.flink/connector/nebula/options/SinkNodeOptions.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/options/SinkNodeOptions.java
@@ -24,7 +24,7 @@ public class SinkNodeOptions extends ExecutionOptions {
     private SinkNodeOptions(Builder builder) {
         super(builder.graphName, builder.nebulaFields, builder.flinkFields,
               builder.writeMode, builder.batchSize, builder.retryTimes, builder.intervalMs,
-              builder.errorWhenFailed);
+              builder.errorWhenFailed, builder.gqlTemplate);
         this.builder = builder;
         this.nodeType = builder.nodeType;
     }
@@ -53,6 +53,7 @@ public class SinkNodeOptions extends ExecutionOptions {
 
         private int     retryTimes      = DEFAULT_RETRY_TIMES;
         private boolean errorWhenFailed = DEFAULT_ERROR_WHEN_FAILED;
+        private String  gqlTemplate;
 
         public Builder withGraphName(String graphName) {
             this.graphName = graphName;
@@ -96,6 +97,11 @@ public class SinkNodeOptions extends ExecutionOptions {
 
         public Builder withErrorWhenFailed(boolean errorWhenFailed) {
             this.errorWhenFailed = errorWhenFailed;
+            return this;
+        }
+
+        public Builder withGqlTemplate(String gqlTemplate) {
+            this.gqlTemplate = gqlTemplate;
             return this;
         }
 

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaEdgeBatchExecutor.java
@@ -9,7 +9,9 @@ package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.driver.graph.data.ResultSet;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.connector.nebula.connection.GraphProvider;
 import org.apache.flink.connector.nebula.options.SinkEdgeOptions;
 import org.apache.flink.connector.nebula.utils.NebulaEdge;
@@ -57,39 +59,63 @@ public class NebulaEdgeBatchExecutor implements NebulaBatchExecutor<Row> {
         }
         NebulaEdges nebulaEdges = new NebulaEdges(schema, nebulaEdgeList);
         // generate the write ngql statement
-        String statement = null;
-        switch (executionOptions.getWriteMode()) {
-            case INSERT:
-            case INSERTIGNORE:
-            case INSERTREPLACE:
-            case INSERTUPDATE:
-                statement = nebulaEdges.getInsertStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getWriteMode(),
-                                                           executionOptions.getFlinkSrcPkFields(),
-                                                           executionOptions.getNebulaSrcPks(),
-                                                           executionOptions.getFlinkDstPkFields(),
-                                                           executionOptions.getNebulaDstPks(),
-                                                           executionOptions.getFlinkFields(),
-                                                           executionOptions.getNebulaFields());
-                break;
-            case UPDATE:
-                statement = nebulaEdges.getUpdateStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getFlinkSrcPkFields(),
-                                                           executionOptions.getNebulaSrcPks(),
-                                                           executionOptions.getFlinkDstPkFields(),
-                                                           executionOptions.getNebulaDstPks(),
-                                                           executionOptions.getFlinkFields(),
-                                                           executionOptions.getNebulaFields());
-                break;
-            case DELETE:
-                statement = nebulaEdges.getDeleteStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getFlinkSrcPkFields(),
-                                                           executionOptions.getNebulaSrcPks(),
-                                                           executionOptions.getFlinkDstPkFields(),
-                                                           executionOptions.getNebulaDstPks());
-                break;
-            default:
-                throw new IllegalArgumentException("write mode is not supported");
+        String statement;
+        if (executionOptions.hasCustomGqlTemplate()) {
+            Map<String, String> values = new HashMap<>();
+            values.put("TABLE",
+                       nebulaEdges.buildTableClause(executionOptions.getFlinkSrcPkFields(),
+                                                    executionOptions.getNebulaSrcPks(),
+                                                    executionOptions.getFlinkDstPkFields(),
+                                                    executionOptions.getNebulaDstPks(),
+                                                    executionOptions.getFlinkFields(),
+                                                    executionOptions.getNebulaFields()));
+            values.put("GRAPH", executionOptions.getGraphName());
+            values.put("TYPE", executionOptions.getEdgeType());
+            values.put("LABEL", executionOptions.getEdgeType());
+            values.put("WRITE_MODE", executionOptions.getWriteMode().name());
+            values.put("WRITE_MODE_NGQL", executionOptions.getWriteMode().getMode());
+            statement = NebulaGqlTemplateEngine.render(executionOptions.getGqlTemplate(), values);
+        } else {
+            statement = null;
+            List<String> flinkSrcPkFields = executionOptions.getFlinkSrcPkFields();
+            List<String> nebulaSrcPks = executionOptions.getNebulaSrcPks();
+            List<String> flinkDstPkFields = executionOptions.getFlinkDstPkFields();
+            List<String> nebulaDstPks = executionOptions.getNebulaDstPks();
+            List<String> flinkFields = executionOptions.getFlinkFields();
+            List<String> nebulaFields = executionOptions.getNebulaFields();
+            switch (executionOptions.getWriteMode()) {
+                case INSERT:
+                case INSERTIGNORE:
+                case INSERTREPLACE:
+                case INSERTUPDATE:
+                    statement = nebulaEdges.getInsertStatement(executionOptions.getGraphName(),
+                                                               executionOptions.getWriteMode(),
+                                                               flinkSrcPkFields,
+                                                               nebulaSrcPks,
+                                                               flinkDstPkFields,
+                                                               nebulaDstPks,
+                                                               flinkFields,
+                                                               nebulaFields);
+                    break;
+                case UPDATE:
+                    statement = nebulaEdges.getUpdateStatement(executionOptions.getGraphName(),
+                                                               flinkSrcPkFields,
+                                                               nebulaSrcPks,
+                                                               flinkDstPkFields,
+                                                               nebulaDstPks,
+                                                               flinkFields,
+                                                               nebulaFields);
+                    break;
+                case DELETE:
+                    statement = nebulaEdges.getDeleteStatement(executionOptions.getGraphName(),
+                                                               flinkSrcPkFields,
+                                                               nebulaSrcPks,
+                                                               flinkDstPkFields,
+                                                               nebulaDstPks);
+                    break;
+                default:
+                    throw new IllegalArgumentException("write mode is not supported");
+            }
         }
 
         // execute ngql statement

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaGqlTemplateEngine.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaGqlTemplateEngine.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package org.apache.flink.connector.nebula.sink;
+
+import java.util.Map;
+
+public final class NebulaGqlTemplateEngine {
+    public static final String TABLE_PLACEHOLDER = "{{TABLE}}";
+
+    private NebulaGqlTemplateEngine() {
+    }
+
+    public static String render(String template, Map<String, String> values) {
+        if (template == null || template.trim().isEmpty()) {
+            throw new IllegalArgumentException("gql-template is empty");
+        }
+        if (!template.contains(TABLE_PLACEHOLDER)) {
+            throw new IllegalArgumentException(
+                    "gql-template must contain {{TABLE}} placeholder");
+        }
+        String result = template;
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            result = result.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return result;
+    }
+}
+

--- a/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaNodeBatchExecutor.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/sink/NebulaNodeBatchExecutor.java
@@ -8,7 +8,9 @@ package org.apache.flink.connector.nebula.sink;
 
 import com.vesoft.nebula.driver.graph.data.ResultSet;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.connector.nebula.connection.GraphProvider;
 import org.apache.flink.connector.nebula.options.SinkNodeOptions;
 import org.apache.flink.connector.nebula.utils.NebulaNode;
@@ -56,31 +58,45 @@ public class NebulaNodeBatchExecutor implements NebulaBatchExecutor<Row> {
         }
         NebulaNodes nebulaNodes = new NebulaNodes(schema, nebulaVertexList);
         // generate the write ngql statement
-        String statement = null;
-        switch (executionOptions.getWriteMode()) {
-            case INSERT:
-            case INSERTIGNORE:
-            case INSERTREPLACE:
-            case INSERTUPDATE:
-                statement = nebulaNodes.getInsertStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getWriteMode(),
-                                                           executionOptions.getFlinkFields(),
-                                                           executionOptions.getNebulaFields());
-                break;
-            case UPDATE:
-                statement = nebulaNodes.getUpdateStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getFlinkFields(),
-                                                           executionOptions.getNebulaFields());
-                break;
-            case DELETE:
-            case DETACHDELETE:
-                statement = nebulaNodes.getDeleteStatement(executionOptions.getGraphName(),
-                                                           executionOptions.getWriteMode(),
-                                                           executionOptions.getFlinkFields(),
-                                                           executionOptions.getNebulaFields());
-                break;
-            default:
-                throw new IllegalArgumentException("write mode is not supported");
+        String statement;
+        if (executionOptions.hasCustomGqlTemplate()) {
+            Map<String, String> values = new HashMap<>();
+            values.put("TABLE",
+                       nebulaNodes.buildTableClause(executionOptions.getFlinkFields(),
+                                                    executionOptions.getNebulaFields()));
+            values.put("GRAPH", executionOptions.getGraphName());
+            values.put("TYPE", executionOptions.getNodeType());
+            values.put("LABEL", executionOptions.getNodeType());
+            values.put("WRITE_MODE", executionOptions.getWriteMode().name());
+            values.put("WRITE_MODE_NGQL", executionOptions.getWriteMode().getMode());
+            statement = NebulaGqlTemplateEngine.render(executionOptions.getGqlTemplate(), values);
+        } else {
+            statement = null;
+            switch (executionOptions.getWriteMode()) {
+                case INSERT:
+                case INSERTIGNORE:
+                case INSERTREPLACE:
+                case INSERTUPDATE:
+                    statement = nebulaNodes.getInsertStatement(executionOptions.getGraphName(),
+                                                               executionOptions.getWriteMode(),
+                                                               executionOptions.getFlinkFields(),
+                                                               executionOptions.getNebulaFields());
+                    break;
+                case UPDATE:
+                    statement = nebulaNodes.getUpdateStatement(executionOptions.getGraphName(),
+                                                               executionOptions.getFlinkFields(),
+                                                               executionOptions.getNebulaFields());
+                    break;
+                case DELETE:
+                case DETACHDELETE:
+                    statement = nebulaNodes.getDeleteStatement(executionOptions.getGraphName(),
+                                                               executionOptions.getWriteMode(),
+                                                               executionOptions.getFlinkFields(),
+                                                               executionOptions.getNebulaFields());
+                    break;
+                default:
+                    throw new IllegalArgumentException("write mode is not supported");
+            }
         }
 
         // execute ngql statement

--- a/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/table/NebulaDynamicTableFactory.java
@@ -21,6 +21,7 @@ import org.apache.flink.connector.nebula.options.SinkNodeOptions;
 import org.apache.flink.connector.nebula.options.SourceEdgeOptions;
 import org.apache.flink.connector.nebula.options.SourceExecutionOptions;
 import org.apache.flink.connector.nebula.options.SourceNodeOptions;
+import org.apache.flink.connector.nebula.sink.NebulaGqlTemplateEngine;
 import org.apache.flink.connector.nebula.utils.DataTypeEnum;
 import org.apache.flink.connector.nebula.utils.NebulaConstant;
 import org.apache.flink.connector.nebula.utils.WriteModeEnum;
@@ -154,6 +155,12 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
             .noDefaultValue()
             .withDescription("batch commit interval in milliseconds.");
 
+    public static final ConfigOption<String> GQL_TEMPLATE = ConfigOptions
+            .key("gql-template")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("custom ngql template, must include {{TABLE}} placeholder.");
+
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final FactoryUtil.TableFactoryHelper helper =
@@ -191,6 +198,10 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                     String.format("The value of '%s' option should not be negative, but is %s.",
                                   TIMEOUT.key(), config.get(TIMEOUT)));
         }
+        if (config.getOptional(GQL_TEMPLATE).isPresent()
+                && !config.get(GQL_TEMPLATE).contains(NebulaGqlTemplateEngine.TABLE_PLACEHOLDER)) {
+            throw new IllegalArgumentException("gql-template must contain {{TABLE}} placeholder");
+        }
     }
 
     private ConnectionOptions getConnectionOptions(ReadableConfig config) {
@@ -220,6 +231,7 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .withFlinkFields(fields)
                             .withNebulaFields(fields)
                             .withWriteMode(writeMode);
+            config.getOptional(GQL_TEMPLATE).ifPresent(builder::withGqlTemplate);
             config.getOptional(BATCH_SIZE).ifPresent(builder::withBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::withIntervalMs);
             return builder.build();
@@ -247,6 +259,7 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
                             .withNebulaSrcPks(nebulaSrcPks)
                             .withNebulaDstPks(nebulaDstPks)
                             .withWriteMode(writeMode);
+            config.getOptional(GQL_TEMPLATE).ifPresent(builder::withGqlTemplate);
             config.getOptional(BATCH_SIZE).ifPresent(builder::withBatchSize);
             config.getOptional(BATCH_INTERVAL_MS).ifPresent(builder::withIntervalMs);
             return builder.build();
@@ -327,6 +340,7 @@ public class NebulaDynamicTableFactory implements DynamicTableSourceFactory,
         set.add(DST_PK_COLUMNS);
         set.add(WRITE_MODE);
         set.add(PK_COLUMNS);
+        set.add(GQL_TEMPLATE);
         return set;
     }
 }

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaEdges.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaEdges.java
@@ -53,8 +53,7 @@ public class NebulaEdges implements Serializable {
                 throw new IllegalArgumentException("insert mode is illegal for insert:"
                                                            + insertMode);
         }
-        String format = "TABLE t{%s} = \n"
-                + "%s \n"
+        String format = "%s\n"
                 + "USE `%s` \n"
                 + "FOR r IN t \n"
                 + "OPTIONAL MATCH (%s@`%s`) WHERE %s "
@@ -62,8 +61,12 @@ public class NebulaEdges implements Serializable {
                 + "%s (%s)-[@`%s`{%s}]->(%s)";
 
         return String.format(format,
-                             getTableHeaders(flinkSrcFields, flinkDstFields, flinkFields),
-                             getTableValues(nebulaSrcPks, nebulaDstPks, nebulaFields),
+                             buildTableClause(flinkSrcFields,
+                                              nebulaSrcPks,
+                                              flinkDstFields,
+                                              nebulaDstPks,
+                                              flinkFields,
+                                              nebulaFields),
                              graphName,
                              SRC_NODE_ALIAS,
                              edgeSchema.getSrcNodeTypeName(),
@@ -76,6 +79,17 @@ public class NebulaEdges implements Serializable {
                              edgeSchema.getEdgeTypeName(),
                              getProperties(nebulaFields),
                              DST_NODE_ALIAS);
+    }
+
+    public String buildTableClause(List<String> flinkSrcFields,
+                                   List<String> nebulaSrcPks,
+                                   List<String> flinkDstFields,
+                                   List<String> nebulaDstPks,
+                                   List<String> flinkFields,
+                                   List<String> nebulaFields) {
+        return String.format("TABLE t{%s} = \n%s ",
+                             getTableHeaders(flinkSrcFields, flinkDstFields, flinkFields),
+                             getTableValues(nebulaSrcPks, nebulaDstPks, nebulaFields));
     }
 
 

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaNodes.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/NebulaNodes.java
@@ -75,19 +75,23 @@ public class NebulaNodes implements Serializable {
                 throw new IllegalArgumentException("insert mode is illegal for insert:"
                                                            + insertMode);
         }
-        String format = "TABLE t{%s} = \n"
-                + "%s \n"
+        String format = "%s\n"
                 + "USE `%s` \n"
                 + "FOR r IN t \n"
                 + "%s (@`%s`{%s})";
 
         return String.format(format,
-                             getTableHeaders(flinkFields),
-                             getTableValues(nebulaFields),
+                             buildTableClause(flinkFields, nebulaFields),
                              graphName,
                              insertModeString,
                              nodeSchema.getNodeTypeName(),
                              getProperties(nebulaFields));
+    }
+
+    public String buildTableClause(List<String> flinkFields, List<String> nebulaFields) {
+        return String.format("TABLE t{%s} = \n%s ",
+                             getTableHeaders(flinkFields),
+                             getTableValues(nebulaFields));
     }
 
     /**

--- a/connector/src/main/java/org.apache.flink/connector/nebula/utils/WriteModeEnum.java
+++ b/connector/src/main/java/org.apache.flink/connector/nebula/utils/WriteModeEnum.java
@@ -49,4 +49,8 @@ public enum WriteModeEnum {
     WriteModeEnum(String mode) {
         this.mode = mode;
     }
+
+    public String getMode() {
+        return mode;
+    }
 }

--- a/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaGqlTemplateEngineTest.java
+++ b/connector/src/test/java/org/apache/flink/connector/nebula/sink/NebulaGqlTemplateEngineTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package org.apache.flink.connector.nebula.sink;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NebulaGqlTemplateEngineTest {
+
+    @Test
+    public void testRenderTemplate() {
+        Map<String, String> values = new HashMap<>();
+        values.put("TABLE", "TABLE t{c0} = \n(1)");
+        values.put("GRAPH", "g1");
+        values.put("TYPE", "person");
+
+        String result = NebulaGqlTemplateEngine.render(
+                "{{TABLE}}\nUSE `{{GRAPH}}`\nFOR r IN t\nINSERT (@`{{TYPE}}`{`id`:r.c0})",
+                values);
+
+        Assert.assertTrue(result.contains("TABLE t{c0}"));
+        Assert.assertTrue(result.contains("USE `g1`"));
+        Assert.assertTrue(result.contains("@`person`"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTemplateWithoutTablePlaceholder() {
+        NebulaGqlTemplateEngine.render("USE `g1`", new HashMap<>());
+    }
+}
+


### PR DESCRIPTION
close #112 

template gql must include {{TABLE}}, and can include {{GRAPH}} and {{TYPE}}:
```
{{TABLE}}  
USE `{{GRAPH}}` 
FOR r IN t 
INSERT(@person{id:r.c0})
```

 * the table name must be `t`
 * the table's column names are r.c0,r.c1,r.c2..., the number is the index of column for flink row column.
 * {{TABLE}} in template gql is required, and the gql can also be like: `{{TABLE}}  USE movie INSERT (:Movie{id:10000,name:"movie"})`